### PR TITLE
Add build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+build/

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -16,3 +16,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Converted LAUNCH assembly launcher to portable C11 (launch/main.c).
 - Launcher now relies only on standard C headers; disk and swap file handling use stub implementations.
 - Renamed files in LAUNCH and LAUNCHER directories to lowercase for cross-platform compatibility.
+- Identified program entry points: `Start` in `LAUNCH/launch.asm` (ported as `launch_main`) and `WinMain` in `CODE/STARTUP.CPP`.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,19 @@ This repository is for preservation purposes only and is archived without suppor
 ## License
 
 This repository and its contents are licensed under the GPL v3 license, with additional terms applied. Please see [LICENSE.md](LICENSE.md) for details.
+
+## Entry points
+
+The DOS launcher begins execution at the `Start` label in `LAUNCH/launch.asm`. In the portable version this is exposed as `launch_main` in `LAUNCH/main.c`. Windows builds start in the standard Win32 `WinMain` located in `CODE/STARTUP.CPP`.
+
+## Quick build
+
+A minimal CMake setup is provided for early testing. Run:
+
+```sh
+cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"
+cmake --build build
+```
+
+Compilation currently fails because of missing dependencies and obsolete pragmas, but the commands illustrate the expected process.
+


### PR DESCRIPTION
## Summary
- document entry points for the DOS and Windows launchers
- describe how to build with `cmake -DCMAKE_C_FLAGS="-std=gnu11"`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: unknown pragmas and missing `wwlib32.h`)*

------
https://chatgpt.com/codex/tasks/task_e_68520ff451088325bec7b063a85b31c2