### PR TITLE
Port Set_Bit helpers to portable C

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -14,3 +14,4 @@ The original source relies on several legacy libraries that are no longer readil
 
 As the port progresses, updates on how each dependency has been replaced or stubbed should be recorded here.
 - Converted LAUNCH assembly launcher to portable C11 (launch/main.c).
+- Replaced bit manipulation assembly pragmas in jshell.h with portable C.


### PR DESCRIPTION
## Summary
- remove Watcom-style `#pragma aux` blocks in `jshell.h`
- implement Set_Bit, Get_Bit and related helpers in portable C
- document the change in `PROGRESS.md`

## Testing
- `cmake ..`
- `cmake --build .` *(fails: missing headers and unknown pragmas)*

------
https://chatgpt.com/codex/tasks/task_e_68521b919bac83258a32694f0413b9da