### PR TITLE
Remove far pointer parameters

### DIFF
--- a/CODE/CDFILE.CPP
+++ b/CODE/CDFILE.CPP
@@ -92,11 +92,7 @@ extern int Get_CD_Index (int cd_drive, int timeout);
  * HISTORY:                                                                                    *
  *   09/22/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
-#ifdef WIN32
-int harderr_handler(unsigned int , unsigned int , unsigned int *)
-#else
-int harderr_handler(unsigned int , unsigned int , unsigned int __far *)
-#endif
+int harderr_handler(unsigned int, unsigned int, unsigned int *)
 {
 	return(_HARDERR_FAIL);
 }

--- a/CODE/function.h
+++ b/CODE/function.h
@@ -462,11 +462,7 @@ bool Is_Speaking(void);
 /*
 **	CDFILE.CPP
 */
-#ifdef WIN32
 int harderr_handler(unsigned, unsigned, unsigned *);
-#else
-int harderr_handler(unsigned, unsigned, unsigned __far *);
-#endif
 
 /*
 **	COMBAT.CPP

--- a/WINVQ/VPLAY32/PLYVQA32.CPP
+++ b/WINVQ/VPLAY32/PLYVQA32.CPP
@@ -110,8 +110,7 @@ int __cdecl Get_Key(void);
 int HardErr_Handler(int errval, int ax, int bp, int si);
 #endif
 #else
-int __far HardErr_Handler(unsigned deverror, unsigned errcode,
-		unsigned __far *devhdr);
+int HardErr_Handler(unsigned deverror, unsigned errcode, unsigned *devhdr);
 #endif
 
 
@@ -944,8 +943,7 @@ int HardErr_Handler(int errval, int ax, int bp, int si)
 *
 ****************************************************************************/
 
-int __far HardErr_Handler(unsigned deverror, unsigned errcode,
-		unsigned __far *devhdr)
+int HardErr_Handler(unsigned deverror, unsigned errcode, unsigned *devhdr)
 {
 	/* Prevent compiler warnings. */
 	errcode = errcode;


### PR DESCRIPTION
## Summary
- convert far pointer parameters in `harderr_handler`
- update prototype in `function.h`
- clean up `HardErr_Handler` signature in the video player module

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: unknown pragmas and missing headers)*

------
https://chatgpt.com/codex/tasks/task_e_68521baca5508325addd22fbb9932164