### PR TITLE
Map WWDebugString to LOG_CALL

### DIFF
--- a/CODE/INIT.CPP
+++ b/CODE/INIT.CPP
@@ -1025,10 +1025,10 @@ bool Select_Game(bool fade)
 								assert ( PacketTransport != NULL);
 
 								if (PacketTransport->Init()) {
-									WWDebugString ("RA95 - About to read multiplayer settings.\n");
+                                                                       LOG_MSG("RA95 - About to read multiplayer settings.");
 									Session.Read_MultiPlayer_Settings ();
 
-									WWDebugString ("RA95 - About to call Start_Server or Start_Client.\n");
+                                                                       LOG_MSG("RA95 - About to call Start_Server or Start_Client.");
 									PacketTransport->Start_Listening();
 
 									/*
@@ -1040,29 +1040,29 @@ bool Select_Game(bool fade)
 								} else {
 									delete PacketTransport;
 									PacketTransport = NULL;
-									WWDebugString ("RA95 - Winsock failed to initialise.\n");
+                                                                       LOG_MSG("RA95 - Winsock failed to initialise.");
 									Session.Type = GAME_NORMAL;
 									selection = SEL_EXIT;
 									Special.IsFromWChat = false;
 									break;
 								}
 
-								WWDebugString ("RA95 - About to call Init_Network.\n");
+                                                           LOG_MSG("RA95 - About to call Init_Network.");
 								Init_Network();
 
 
 #else	//WINSOCK_IPX
 
-								WWDebugString ("RA95 - About to initialise Winsock.\n");
+                                                           LOG_MSG("RA95 - About to initialise Winsock.");
 								if (Winsock.Init()) {
-									WWDebugString ("RA95 - About to read multiplayer settings.\n");
+                                                                       LOG_MSG("RA95 - About to read multiplayer settings.");
 									Session.Read_MultiPlayer_Settings ();
 									Server = PlanetWestwoodIsHost;
 
-									WWDebugString ("RA95 - About to set addresses.\n");
+                                                                       LOG_MSG("RA95 - About to set addresses.");
 									Winsock.Set_Host_Address(PlanetWestwoodIPAddress);
 
-									WWDebugString ("RA95 - About to call Start_Server or Start_Client.\n");
+                                                                       LOG_MSG("RA95 - About to call Start_Server or Start_Client.");
 									if (Server) {
 										Winsock.Start_Server();
 									} else {
@@ -1073,53 +1073,53 @@ bool Select_Game(bool fade)
 									/*
 									** Flush out any pending packets from a previous game.
 									*/
-									WWDebugString ("RA95 - About to flush packet queue.\n");
-									WWDebugString ("RA95 - Allocating scrap memory.\n");
+                                                                       LOG_MSG("RA95 - About to flush packet queue.");
+                                                                       LOG_MSG("RA95 - Allocating scrap memory.");
 									char *temp_buffer = new char[1024];
 
-									WWDebugString ("RA95 - Creating timer class instance.\n");
+                                                                       LOG_MSG("RA95 - Creating timer class instance.");
 									CountDownTimerClass ptimer;
 
-									WWDebugString ("RA95 - Entering read loop.\n");
+                                                                       LOG_MSG("RA95 - Entering read loop.");
 									while (Winsock.Read(temp_buffer, 1024)) {
 
-										WWDebugString ("RA95 - Discarding a packet.\n");
+                                                                               LOG_MSG("RA95 - Discarding a packet.");
 										ptimer.Set (30, true);
 										while (ptimer.Time()) {};
-										WWDebugString ("RA95 - Ready to check for more packets.\n");
+                                                                               LOG_MSG("RA95 - Ready to check for more packets.");
 
 									}
-									WWDebugString ("RA95 - About to delete scrap memory.\n");
+                                                                       LOG_MSG("RA95 - About to delete scrap memory.");
 									delete temp_buffer;
 
 
 
 								} else {
-									WWDebugString ("RA95 - Winsock failed to initialise.\n");
+                                                                       LOG_MSG("RA95 - Winsock failed to initialise.");
 									Session.Type = GAME_NORMAL;
 									selection = SEL_EXIT;
 									Special.IsFromWChat = false;
 									break;
 								}
 #endif	//WINSOCK_IPX
-								WWDebugString ("RA95 - About to call Init_Network.\n");
+                                                           LOG_MSG("RA95 - About to call Init_Network.");
 								Init_Network();
 
 								if (DDEServer.Get_MPlayer_Game_Info()) {
-									WWDebugString ("RA95 - About to call Read_Game_Options.\n");
+                                                                       LOG_MSG("RA95 - About to call Read_Game_Options.");
 									Read_Game_Options( NULL );
 								} else {
 									Read_Game_Options( "C&CSPAWN.INI" );
 								}
 #ifdef WINSOCK_IPX
-								WWDebugString ("RA95 - About to set addresses.\n");
+                                                           LOG_MSG("RA95 - About to set addresses.");
 								PacketTransport->Set_Broadcast_Address (PlanetWestwoodIPAddress);
 #endif	//WINSOCK_IPX
 								if (PlanetWestwoodIsHost) {
 
-									WWDebugString ("RA95 - About to call Server_Remote_Connect.\n");
+                                                                       LOG_MSG("RA95 - About to call Server_Remote_Connect.");
 									if (Server_Remote_Connect()) {
-										WWDebugString ("RA95 - Server_Remote_Connect returned success.\n");
+                                                                               LOG_MSG("RA95 - Server_Remote_Connect returned success.");
 										break;
 									} else {
 										/*
@@ -1137,9 +1137,9 @@ bool Select_Game(bool fade)
 										break;
 									}
 								} else {
-									WWDebugString ("RA95 - About to call Client_Remote_Connect.\n");
+                                                                       LOG_MSG("RA95 - About to call Client_Remote_Connect.");
 									if (Client_Remote_Connect()) {
-										WWDebugString ("RA95 - Client_Remote_Connect returned success.\n");
+                                                                               LOG_MSG("RA95 - Client_Remote_Connect returned success.");
 										break;
 									} else {
 										/*
@@ -1247,7 +1247,7 @@ bool Select_Game(bool fade)
 						**	Network (IPX): start a new network game.
 						*/
 						case GAME_IPX:
-							WWDebugString ("RA95 - Game type is IPX.\n");
+                                                   LOG_MSG("RA95 - Game type is IPX.");
 							/*
 							** Init network system & remote-connect
 							*/
@@ -1270,7 +1270,7 @@ bool Select_Game(bool fade)
 //							}
 
 #endif	//WINSOCK_IPX
-							WWDebugString ("RA95 - About to call Init_Network.\n");
+                                                   LOG_MSG("RA95 - About to call Init_Network.");
 							if (Session.Type == GAME_IPX && Init_Network() && Remote_Connect()) {
 #ifdef FIXIT_VERSION_3
 								Options.ScoreVolume = Options.MultiScoreVolume;

--- a/CODE/STARTUP.CPP
+++ b/CODE/STARTUP.CPP
@@ -488,7 +488,7 @@ LOG_CALL("%s entered\n", __func__);
 					/*
 					** Aaaarrgghh!
 					*/
-					WWDebugString(TEXT_DDRAW_ERROR);WWDebugString("\n");
+                                       LOG_MSG(TEXT_DDRAW_ERROR);
 					MessageBox(MainWindow, TEXT_DDRAW_ERROR, TEXT_SHORT_TITLE, MB_ICONEXCLAMATION|MB_OK);
 					if (WindowsTimer) delete WindowsTimer;
 					return (EXIT_FAILURE);
@@ -757,7 +757,7 @@ bool InitDDraw(void)
 		if (surface_capabilities.dwCaps & DDSCAPS_SYSTEMMEMORY)
 			{
 			/* Aaaarrgghh! */
-			WWDebugString(TEXT_DDRAW_ERROR);WWDebugString("\n");
+                        LOG_MSG(TEXT_DDRAW_ERROR);
 			MessageBox(MainWindow, TEXT_DDRAW_ERROR, TEXT_SHORT_TITLE, MB_ICONEXCLAMATION|MB_OK);
 
 			if (WindowsTimer)

--- a/CODE/externs.h
+++ b/CODE/externs.h
@@ -50,7 +50,8 @@
 #include	"credits.h"
 #include	"goptions.h"
 #include	"options.h"
-#include	"infantry.h"
+#include        "infantry.h"
+#include "../src/debug_log.h"
 
 
 extern char _staging_buffer[32000];
@@ -448,7 +449,9 @@ void Do_Vortex (int x, int y, int frame);
 extern bool ReadyToQuit;							//Are we about to exit cleanly
 extern bool InDebugger;							//Are we being run from a debugger
 void Memory_Error_Handler(void);				//Memory error handler function
+#ifndef ENABLE_LOGGING
 void WWDebugString (char *string);
+#endif
 #else
 extern bool IsTheaterShape;
 #endif	//WIN32

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -26,6 +26,8 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Renamed files in LAUNCH and LAUNCHER directories to lowercase for cross-platform compatibility.
 - Identified program entry points: `Start` in `LAUNCH/launch.asm` (ported as `launch_main`) and `WinMain` in `CODE/STARTUP.CPP`.
 - Added debug logging macros for tracing execution (src/debug_log.h).
+- Legacy `WWDebugString` calls now map to `LOG_CALL` via `LOG_MSG` for
+  consistent formatting.
 - Cleaned up function.h includes for C11 compatibility and wrapped Windows-only headers.
 - Documented legacy pragmas and removed `watcom.h` includes (PRAGMA.md).
 - Added stub `CODE/wwlib32/wwlib32.h` for missing Windows library.

--- a/src/debug_log.h
+++ b/src/debug_log.h
@@ -4,8 +4,13 @@
 #ifdef ENABLE_LOGGING
 #include <stdio.h>
 #define LOG_CALL(fmt, ...) do { fprintf(stderr, fmt, __VA_ARGS__); } while (0)
+/* Generic message helper used by new logging wrappers */
+#define LOG_MSG(msg) LOG_CALL("%s\n", msg)
+/* Map legacy debug output to the new logging system */
+#define WWDebugString(str) LOG_CALL("%s", str)
 #else
 #define LOG_CALL(fmt, ...) do { } while (0)
+#define LOG_MSG(msg) do { } while (0)
 #endif
 
 #endif /* DEBUG_LOG_H */


### PR DESCRIPTION
## Summary
- hook legacy `WWDebugString` into new `LOG_CALL` system
- replace startup/network debug prints with `LOG_MSG`
- record migration in `PROGRESS.md`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: conio.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685275a363048325891488864be9c6e2