### PR TITLE
Add LVGL logging and conio replacement

### DIFF
--- a/CODE/CMakeLists.txt
+++ b/CODE/CMakeLists.txt
@@ -280,6 +280,7 @@ XPIPE.CPP
 XSTRAW.CPP
 _WSPROTO.CPP
 lvgl/lvgl_bridge.c
+lvgl/terminal.c
 )
 
 set(CODE_ASM
@@ -312,6 +313,7 @@ target_include_directories(gamecode PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/../WIN32LIB/INCLUDE
     ${CMAKE_CURRENT_LIST_DIR}/../VQ/INCLUDE/WWLIB32
     ${CMAKE_CURRENT_LIST_DIR}/../src/ddraw
+    ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
 target_compile_definitions(gamecode PUBLIC $<$<BOOL:${USE_LVGL}>:USE_LVGL>)

--- a/CODE/function.h
+++ b/CODE/function.h
@@ -41,7 +41,7 @@
 /*
 **	!!!DEFINE!!!  "NDEBUG" if the assertion code is to be !!!REMOVED!!! from the project.
 */
-#define	NDEBUG
+/* #define NDEBUG */
 
 /*
  * Formerly disabled a Watcom-specific warning. No longer needed in C11.
@@ -60,7 +60,6 @@
 #ifdef WIN32
 //#define WIN32_LEAN_AND_MEAN
 #include	<windows.h>
-#include <stdbool.h>
 #define WWFILE_H
 #define RAWFILE_H
 #define MONOC_H
@@ -68,6 +67,7 @@
 #define	_MAX_NAME	_MAX_FNAME
 
 #endif
+#include <stdbool.h>
 
 #ifndef BITMAPCLASS
 #define BITMAPCLASS
@@ -192,7 +192,6 @@ typedef struct {
 extern bool GameActive;
 extern long LParam;
 
-#include	<assert.h>
 #include	"vector.h"
 #include	"heap.h"
 #include	"ccfile.h"
@@ -337,22 +336,6 @@ extern int Get_CD_Drive(void);
 extern void Fatal(char const *message, ...);
 
 #ifdef WIN32
-
-/*
-** For WIN32, replace the assert macro so we get an error on the debugger screen
-**  where we can see it.
-**
-*/
-#ifdef assert
-#undef assert
-#endif	//assert
-void Assert_Failure (char *expression, int line, char *file);
-
-#ifdef NDEBUG
- #define assert(__ignore) ((void)0)
-#else
- #define assert(expr)   ((expr)?(void)0:Assert_Failure(#expr,__LINE__,__FILE__))
-#endif	//NDEBUG
 
 extern void Free_Interpolated_Palettes(void);
 extern int Load_Interpolated_Palettes(char const *filename, BOOL add=FALSE);

--- a/CODE/lvgl/terminal.c
+++ b/CODE/lvgl/terminal.c
@@ -1,0 +1,99 @@
+#include "terminal.h"
+#include "lvgl/lvgl.h"
+#include <string.h>
+
+#define TERMINAL_ANIM_TIME   100
+#define TERMINAL_LOG_LENGTH  512
+
+static lv_obj_t * win;
+static char txt_log[TERMINAL_LOG_LENGTH + 1];
+static lv_obj_t * label;
+static lv_obj_t * clr_btn;
+
+static lv_res_t clr_click_action(lv_obj_t * btn);
+static lv_res_t win_close_action(lv_obj_t * btn);
+
+lv_obj_t * terminal_create(void)
+{
+    static lv_style_t style_bg;
+    lv_style_copy(&style_bg, &lv_style_pretty);
+    style_bg.body.main_color = LV_COLOR_MAKE(0x30, 0x30, 0x30);
+    style_bg.body.grad_color = LV_COLOR_MAKE(0x30, 0x30, 0x30);
+    style_bg.body.border.color = LV_COLOR_WHITE;
+    style_bg.text.color = LV_COLOR_MAKE(0xE0, 0xE0, 0xE0);
+
+    win = lv_win_create(lv_scr_act(), NULL);
+    lv_win_set_style(win, LV_WIN_STYLE_BG, &style_bg);
+    lv_win_set_sb_mode(win, LV_SB_MODE_AUTO);
+    lv_win_add_btn(win, LV_SYMBOL_CLOSE, win_close_action);
+    lv_win_set_layout(win, LV_LAYOUT_PRETTY);
+
+    label = lv_label_create(win, NULL);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_BREAK);
+    lv_obj_set_width(label, lv_win_get_width(win));
+    lv_label_set_static_text(label, txt_log);
+
+    clr_btn = lv_btn_create(win, NULL);
+    lv_cont_set_fit(clr_btn, true, true);
+    lv_btn_set_action(clr_btn, LV_BTN_ACTION_CLICK, clr_click_action);
+    lv_obj_t * btn_label = lv_label_create(clr_btn, NULL);
+    lv_label_set_text(btn_label, "Clear");
+
+    return win;
+}
+
+void terminal_add(const char * txt_in)
+{
+    if(win == NULL) return;
+
+    uint16_t txt_len = strlen(txt_in);
+    uint16_t old_len = strlen(txt_log);
+
+    if(txt_len > TERMINAL_LOG_LENGTH) {
+        txt_in += (txt_len - TERMINAL_LOG_LENGTH);
+        txt_len = TERMINAL_LOG_LENGTH;
+        old_len = 0;
+    }
+    else if(old_len + txt_len > TERMINAL_LOG_LENGTH) {
+        uint16_t new_start;
+        for(new_start = 0; new_start < old_len; new_start++) {
+            if(txt_log[new_start] == '\n') {
+                if(new_start >= txt_len) {
+                    while(txt_log[new_start] == '\n' || txt_log[new_start] == '\r') new_start++;
+                    break;
+                }
+            }
+        }
+        if(new_start == old_len) {
+            new_start = old_len - (TERMINAL_LOG_LENGTH - txt_len);
+        }
+        for(uint16_t j = new_start; j < old_len; j++) {
+            txt_log[j - new_start] = txt_log[j];
+        }
+        old_len = old_len - new_start;
+        txt_log[old_len] = '\0';
+    }
+
+    memcpy(&txt_log[old_len], txt_in, txt_len);
+    txt_log[old_len + txt_len] = '\0';
+
+    lv_label_set_static_text(label, txt_log);
+    lv_win_focus(win, clr_btn, TERMINAL_ANIM_TIME);
+}
+
+static lv_res_t clr_click_action(lv_obj_t * btn)
+{
+    (void)btn;
+    txt_log[0] = '\0';
+    lv_label_set_static_text(label, txt_log);
+    return LV_RES_OK;
+}
+
+static lv_res_t win_close_action(lv_obj_t * btn)
+{
+    (void)btn;
+    lv_obj_del(win);
+    win = NULL;
+    return LV_RES_INV;
+}
+

--- a/CODE/lvgl/terminal.h
+++ b/CODE/lvgl/terminal.h
@@ -1,0 +1,17 @@
+#ifndef TERMINAL_H
+#define TERMINAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "lvgl/lvgl.h"
+
+lv_obj_t * terminal_create(void);
+void terminal_add(const char * txt_in);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* TERMINAL_H */

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -42,4 +42,11 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - `GScreenClass::Blit_Display` now bypasses DirectDraw when `USE_LVGL` is
   enabled and hands the frame buffer to `lvgl_blit`.
 - When `USE_LVGL` is passed to CMake the LVGL library is initialized at startup
-  and `lvgl_blit` copies each frame to a canvas instead of relying on DirectDraw. 
+  and `lvgl_blit` copies each frame to a canvas instead of relying on DirectDraw.
+- Added a Linux-compatible `conio.h` replacement under `src` and updated the
+  build system to search this directory so legacy `<conio.h>` includes resolve.
+- `src/debug_log.h` now maps logging calls to LVGL's log module for consistent
+  output when `ENABLE_LOGGING` is defined. A minimal `lv_conf.h` enables logging
+  with `LV_LOG_LEVEL_INFO`.
+- Simplified function.h by removing Windows-only assert hooks and redundant includes.
+- Implemented an LVGL-based terminal widget for on-screen debugging (`terminal.c` and `terminal.h`).

--- a/src/conio.h
+++ b/src/conio.h
@@ -1,0 +1,352 @@
+#ifndef CONIO_H
+#define CONIO_H
+
+#include <termios.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define cprintf printf
+#define cscanf scanf
+#define cgets gets
+
+#define CLEAR "\x1b[2J"
+#define SET11 "\x1b[1;1f"
+#define CURSOR_UP "\x1b[1A"
+#define ERASE_LINE "\x1b[2K"
+#define BLINK_SLOW "\x1b[5m"
+#define BLINK_RAPID "\x1b[6m"
+#define CC_CLEAR "\x1b[0m"
+
+enum COLORS
+{
+  BLACK = 0,
+  BLUE = 1,
+  GREEN = 2,
+  CYAN = 3,
+  RED = 4,
+  MAGENTA = 5,
+  BROWN = 6,
+  LIGHTGRAY = 7,
+  DARKGRAY = 8,
+  LIGHTBLUE = 9,
+  LIGHTGREEN = 10,
+  LIGHTCYAN = 11,
+  LIGHTRED = 12,
+  LIGHTMAGENTA = 13,
+  YELLOW = 14,
+  WHITE = 15,
+  BLINK = 128
+};
+
+static struct termios oldterm, newterm;
+
+void initTermios(int echo)
+{
+    tcgetattr(0, &oldterm);
+    newterm = oldterm;
+    newterm.c_lflag &= ~ICANON;
+    newterm.c_lflag &= echo ? ECHO : ~ECHO;
+    tcsetattr(0, TCSANOW, &newterm);
+}
+void resetTermios(void)
+{
+    tcsetattr(0, TCSANOW, &oldterm);
+}
+
+int getch_(int echo)
+{
+    int ch;
+    initTermios(echo);
+    ch = getchar();
+    resetTermios();
+    return ch;
+}
+
+void cagxy(unsigned int x, unsigned int y)
+{
+    printf("%s\x1b[%d;%df", CLEAR, y, x);
+}
+
+void clrscr()
+{
+    printf("%s%s",CLEAR, SET11);
+}
+
+int getch(void)
+{
+    return getch_(0);
+}
+
+int getche(void)
+{
+    return getch_(1);
+}
+
+void gotox(unsigned int x)
+{
+    printf("\x1b[%dG", x);
+}
+
+// added the fflush function, it might seem like it does nothing, but it helps on some glitches when using gotoxy
+void gotoxy(unsigned int x, unsigned int y)
+{
+    printf("\x1b[%d;%df", y, x);
+    fflush(stdout);
+}
+
+void nocursor()
+{
+    printf("\x1b[?25l");
+}
+
+void normvideo()
+{
+    printf("\x1b[0m");
+}
+
+void showcursor()
+{
+    printf("\x1b[?25h");
+}
+
+void textcolor(int newcolor)
+{
+  //https://en.wikipedia.org/wiki/ANSI_escape_code
+
+  const char * s = "\x1b[30m";
+
+  switch (newcolor)
+  {
+  case BLACK:
+    s = "\x1b[30m";
+    break;
+
+  case BLUE:
+    s = "\x1b[34m";
+    break;
+
+  case GREEN:
+    s = "\x1b[32m";
+    break;
+
+  case CYAN:
+    s = "\x1b[36m";
+    break;
+
+  case RED:
+    s = "\x1b[31;1m";
+    break;
+
+  case MAGENTA:
+    s = "\x1b[35m";
+    break;
+
+  case BROWN:
+    s = "\x1b[31m";
+    break;
+
+  case LIGHTGRAY:
+    s = "\x1b[30;1m";
+    break;
+
+  case DARKGRAY:
+    s = "\x1b[30m";
+    break;
+
+  case LIGHTBLUE:
+    s = "\x1b[34;1m";
+    break;
+
+  case LIGHTGREEN:
+    s = "\x1b[32,1m";;
+    break;
+
+  case LIGHTCYAN:
+    s = "\x1b[36;1m";
+    break;
+
+  case LIGHTRED:
+    s = "\x1b[31;1m";
+    break;
+
+  case LIGHTMAGENTA:
+    s = "\x1b[35;1m";
+    break;
+
+  case YELLOW:
+    s = "\x1b[33;1m";
+    break;
+
+  case WHITE:
+    s = "\x1b[37;1m";
+    break;
+
+  case BLINK:
+    s = "\x1b[30m";
+    break;
+  };
+
+  printf("%s", s);
+}
+
+void textbackground(int newcolor)
+{
+  //https://en.wikipedia.org/wiki/ANSI_escape_code
+
+  const char * s = "\x1b[40m";
+
+  switch (newcolor)
+  {
+  case BLACK:
+    s = "\x1b[40m";
+    break;
+
+  case BLUE:
+    s = "\x1b[44m";
+    break;
+
+  case GREEN:
+    s = "\x1b[42m";
+    break;
+
+  case CYAN:
+    s = "\x1b[46m";
+    break;
+
+  case RED:
+    s = "\x1b[41;1m";
+    break;
+
+  case MAGENTA:
+    s = "\x1b[45m";
+    break;
+
+  case BROWN:
+    s = "\x1b[41m";
+    break;
+
+  case LIGHTGRAY:
+    s = "\x1b[40;1m";
+    break;
+
+  case DARKGRAY:
+    s = "\x1b[40m";
+    break;
+
+  case LIGHTBLUE:
+    s = "\x1b[44;1m";
+    break;
+
+  case LIGHTGREEN:
+    s = "\x1b[42,1m";;
+    break;
+
+  case LIGHTCYAN:
+    s = "\x1b[46;1m";
+    break;
+
+  case LIGHTRED:
+    s = "\x1b[41;1m";
+    break;
+
+  case LIGHTMAGENTA:
+    s = "\x1b[45;1m";
+    break;
+
+  case YELLOW:
+    s = "\x1b[43;1m";
+    break;
+
+  case WHITE:
+    s = "\x1b[47;1m";
+    break;
+
+  case BLINK:
+    s = "\x1b[40m";
+    break;
+  };
+
+  printf("%s", s);
+}
+
+void delline()
+{
+    printf("%s%s", ERASE_LINE, CURSOR_UP);
+}
+
+void clreol()
+{
+    printf("%s",CLEAR);
+}
+int putch(const char c)
+{
+    printf("%c",c);
+    return (int)c;
+}
+
+int cputs(const char*str)
+{
+    printf(str);
+    return 0;
+}
+
+
+int wherexy(int *x, int *y)
+{
+    printf("\033[6n");
+    if(getch() != '\x1B') return 0;
+    if(getch() != '\x5B') return 0;
+    int in;
+    int ly = 0;
+    while((in = getch()) != ';')
+        ly = ly * 10 + in - '0';
+    int lx = 0;
+    while((in = getch()) != 'R')
+        lx = lx * 10 + in - '0';
+    *x = lx;
+    *y = ly;
+}
+int wherex()
+{
+    int x=0,y=0;
+    wherexy(&x, &y);
+    return x;
+}
+
+int wherey()
+{
+    int x=0,y=0;
+    wherexy(&x, &y);
+    return y;
+}
+
+int kbhit()
+{
+    struct termios oldt, newt;
+    int ch;
+    int oldf;
+
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+    oldf = fcntl(STDIN_FILENO, F_GETFL, 0);
+    fcntl(STDIN_FILENO, F_SETFL, oldf | O_NONBLOCK);
+
+    ch = getchar();
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+    fcntl(STDIN_FILENO, F_SETFL, oldf);
+
+    if(ch != EOF)
+    {
+        ungetc(ch, stdin);
+        return 1;
+    }
+    return 0;
+}
+#endif
+

--- a/src/debug_log.h
+++ b/src/debug_log.h
@@ -2,12 +2,12 @@
 #define DEBUG_LOG_H
 
 #ifdef ENABLE_LOGGING
-#include <stdio.h>
-#define LOG_CALL(fmt, ...) do { fprintf(stderr, fmt, __VA_ARGS__); } while (0)
+#include "lvgl/src/misc/lv_log.h"
+#define LOG_CALL(fmt, ...) LV_LOG_INFO(fmt, __VA_ARGS__)
 /* Generic message helper used by new logging wrappers */
-#define LOG_MSG(msg) LOG_CALL("%s\n", msg)
+#define LOG_MSG(msg) LV_LOG_USER("%s", msg)
 /* Map legacy debug output to the new logging system */
-#define WWDebugString(str) LOG_CALL("%s", str)
+#define WWDebugString(str) LV_LOG(str)
 #else
 #define LOG_CALL(fmt, ...) do { } while (0)
 #define LOG_MSG(msg) do { } while (0)

--- a/src/lv_conf.h
+++ b/src/lv_conf.h
@@ -1,0 +1,10 @@
+#ifndef LV_CONF_H
+#define LV_CONF_H
+
+#define LV_USE_LOG 1
+#define LV_LOG_LEVEL LV_LOG_LEVEL_INFO
+#define LV_LOG_PRINTF 1
+#define LV_LOG_USE_TIMESTAMP 1
+#define LV_LOG_USE_FILE_LINE 1
+
+#endif /* LV_CONF_H */


### PR DESCRIPTION
## Summary
- add linuxconio replacement as `src/conio.h`
- expose `src` directory to the build so `<conio.h>` resolves
- switch debug logging macros to LVGL's log module
- enable LVGL logging via a minimal `lv_conf.h`
- document the changes in `PROGRESS.md`
- simplify `function.h` header and use standard `assert`
- implement an LVGL terminal widget for on-screen logs

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: io.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685279b729c4832585404c12d94de29d