### PR TITLE
Add keyboard and mouse documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,5 +28,7 @@ Several Markdown files at the repository root contain critical details about the
 - `SHADOWX.md` – explains the `Shadow_Blit` path for DOS builds.
 - `LVGL.md` – documents the LVGL integration. See the `lvgl_init` and `lvgl_blit`
   routines used when `USE_LVGL` is enabled.
+- `KEYBOARD.md` – notes on the keyboard handler and LVGL keyboard integration.
+- `MOUSE.md` – notes on the mouse system and LVGL input devices.
 
 Consult these documents when porting or refactoring code.

--- a/KEYBOARD.md
+++ b/KEYBOARD.md
@@ -1,0 +1,21 @@
+# Keyboard Input
+
+`CODE/key.h` defines the keyboard queue used by the engine. It sets bit masks for shift, control and other modifiers, then exposes the `WWKeyboardClass` interface.
+
+## CODE/key.h
+- The `WWKey_Type` enum lists modifier bits like `WWKEY_SHIFT_BIT` and `WWKEY_RLS_BIT`【F:CODE/key.h†L53-L61】.
+- `WWKeyboardClass` stores a 256 entry state array and a circular buffer to hold pending key presses【F:CODE/key.h†L63-L109】.
+- Two enums translate between ASCII keys and virtual key codes. `KeyNumType` begins at zero and maps codes such as `KN_F1` and `KN_SPACE` to `VK_` values【F:CODE/key.h†L520-L644】.
+
+## CODE/KEYBOARD.CPP
+- `Put_Key_Message` assembles the modifier bits and pushes a key into the queue before passing it to `Put`【F:CODE/KEYBOARD.CPP†L176-L219】.
+- `To_ASCII` converts a queued key to an ASCII character using Windows `ToAscii` and `MapVirtualKey` functions【F:CODE/KEYBOARD.CPP†L226-L297】.
+
+## Using LVGL `lv_keyboard`
+The LVGL demo shows how to spawn a keyboard widget for text areas. A call to `lv_keyboard_create` returns an object that can be toggled by user input:
+```c
+lv_obj_t * kb = lv_keyboard_create(lv_screen_active());
+```
+Event callbacks attach the keyboard to a focused textarea and reveal it for encoder input【F:src/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c†L150-L209】.
+
+When integrating with the game, `lv_keyboard_set_textarea` should be called from the event handler whenever LVGL reports a `LV_EVENT_CLICKED` from an encoder or keypad. The underlying key events will then flow through LVGL's input devices and can be read back via `lv_indev_get_type`.

--- a/MOUSE.md
+++ b/MOUSE.md
@@ -1,0 +1,27 @@
+# Mouse Input
+
+`CODE/mouse.h` describes the animated mouse cursor handler. `MouseClass` inherits from `ScrollClass` and manages frame timing, shape switching and file I/O.
+
+## CODE/mouse.h
+- The handler exposes methods like `Override_Mouse_Shape`, `Revert_Mouse_Shape` and `AI` to update the pointer each tick【F:CODE/mouse.h†L52-L70】.
+- `MouseStruct` holds frame information and hotspot offsets for each cursor shape【F:CODE/mouse.h†L84-L101】.
+- `IsSmall` tracks whether the small cursor variant is active【F:CODE/mouse.h†L100-L106】.
+
+## CODE/MOUSE.CPP
+- `Set_Default_Mouse` sets the current and normal cursor types before delegating to `Override_Mouse_Shape`【F:CODE/MOUSE.CPP†L92-L105】.
+- `Override_Mouse_Shape` changes the cursor sprite and records whether the small version is displayed【F:CODE/MOUSE.CPP†L184-L229】.
+- The `AI` method advances animated cursors based on the timer and forwards input to `ScrollClass::AI`【F:CODE/MOUSE.CPP†L236-L271】.
+
+## Using LVGL `lv_indev`
+LVGL groups input devices behind the `lv_indev` API. The keypad/encoder demo queries each device with `lv_indev_get_next` and assigns them to a group for focus handling:
+```c
+lv_indev_t * indev = NULL;
+for(;;) {
+    indev = lv_indev_get_next(indev);
+    if(!indev) break;
+    lv_indev_type_t indev_type = lv_indev_get_type(indev);
+    if(indev_type == LV_INDEV_TYPE_KEYPAD || indev_type == LV_INDEV_TYPE_ENCODER)
+        lv_indev_set_group(indev, g);
+}
+```
+The active device is retrieved with `lv_indev_active` inside the event callback to attach the onscreen keyboard【F:src/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c†L48-L66】【F:src/lvgl/demos/keypad_encoder/lv_demo_keypad_encoder.c†L192-L209】.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ cmake --build build
 
 Compilation currently fails because of missing dependencies and obsolete pragmas, but the commands illustrate the expected process.
 
+
+## Input devices
+
+- [KEYBOARD.md](KEYBOARD.md) – keyboard queue and LVGL keyboard notes.
+- [MOUSE.md](MOUSE.md) – mouse handler and LVGL input device notes.


### PR DESCRIPTION
## Summary
- document keyboard controls in KEYBOARD.md
- document mouse controls in MOUSE.md
- reference the new docs from README and AGENTS

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: unknown pragmas and missing headers)*

------
https://chatgpt.com/codex/tasks/task_e_6852864a6b5483258b878c569eac46d1