### PR TITLE
Initialize LVGL early and pump events

### DIFF
--- a/CODE/CMakeLists.txt
+++ b/CODE/CMakeLists.txt
@@ -280,6 +280,7 @@ XPIPE.CPP
 XSTRAW.CPP
 _WSPROTO.CPP
 lvgl/lvgl_bridge.c
+lvgl/lvgl_backend.c
 lvgl/terminal.c
 )
 

--- a/CODE/CONQUER.CPP
+++ b/CODE/CONQUER.CPP
@@ -87,6 +87,9 @@ B<A> test;
 
 #include	"function.h"
 #include "../src/debug_log.h"
+#ifdef USE_LVGL
+#include "../src/lvgl/src/lvgl.h"
+#endif
 #ifdef WIN32
 #ifdef WINSOCK_IPX
 #include	"WSProto.h"
@@ -2147,8 +2150,11 @@ LOG_CALL("%s entered\n", __func__);
 	int framedelay;
 
 Mono_Set_Cursor(0,0);
+#ifdef USE_LVGL
+    lv_timer_handler();
+#endif
 
-	if (!GameActive) return(!GameActive);
+        if (!GameActive) return(!GameActive);
 
 #ifdef WIN32
 	/*

--- a/CODE/STARTUP.CPP
+++ b/CODE/STARTUP.CPP
@@ -46,6 +46,10 @@
 #include  "ccdde.h"
 #include	"ipx95.h"
 #endif	//WIN32
+#ifdef USE_LVGL
+#include "../src/lvgl/src/lvgl.h"
+#include "lvgl/lvgl_backend.h"
+#endif
 
 #ifdef MCIMPEG // Denzil 6/15/98
 #include "mcimovie.h"
@@ -115,6 +119,10 @@ int main(int argc, char * argv[])
 {
 #ifdef WIN32
 LOG_CALL("%s entered\n", __func__);
+#ifdef USE_LVGL
+    lv_init();
+    lvgl_init_backend();
+#endif
 
 	#ifndef MPEGMOVIE // Denzil 6/10/98
 	DDSCAPS	surface_capabilities;

--- a/CODE/lvgl/lvgl_backend.c
+++ b/CODE/lvgl/lvgl_backend.c
@@ -1,0 +1,14 @@
+#include "lvgl_backend.h"
+#include "../../src/lvgl/src/lvgl.h"
+#include "../../src/lvgl/src/drivers/lv_drivers.h"
+#include "../externs.h" /* for ScreenWidth/ScreenHeight */
+
+void lvgl_init_backend(void)
+{
+    lv_display_t *disp = lv_sdl_window_create(ScreenWidth, ScreenHeight);
+    lv_sdl_mouse_create();
+    lv_sdl_mousewheel_create();
+    lv_sdl_keyboard_create();
+    lv_display_set_default(disp);
+    lv_sdl_window_set_title(disp, "Red Alert");
+}

--- a/CODE/lvgl/lvgl_backend.h
+++ b/CODE/lvgl/lvgl_backend.h
@@ -1,0 +1,14 @@
+#ifndef LVGL_BACKEND_H
+#define LVGL_BACKEND_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void lvgl_init_backend(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LVGL_BACKEND_H */

--- a/CODE/lvgl/lvgl_bridge.c
+++ b/CODE/lvgl/lvgl_bridge.c
@@ -56,6 +56,7 @@ void lvgl_blit(const struct GraphicBufferClass *page)
 
         canvas = lv_canvas_create(lv_screen_active());
         lv_canvas_set_draw_buf(canvas, canvas_buf);
+        lv_scr_load(canvas);
     }
 
     /* Update the palette from the game's global palette data */

--- a/LAUNCH/main.c
+++ b/LAUNCH/main.c
@@ -13,6 +13,10 @@
 #ifdef _WIN32
 #include <process.h>
 #endif
+#ifdef USE_LVGL
+#include "../src/lvgl/src/lvgl.h"
+#include "../CODE/lvgl/lvgl_backend.h"
+#endif
 
 static const unsigned long REQUIRED_DISK_SPACE = 15UL * 1024 * 1024; /* bytes */
 
@@ -55,6 +59,10 @@ static void delete_swaps(const char *path)
 
 int launch_main(int argc, char **argv)
 {
+    #ifdef USE_LVGL
+    lv_init();
+    lvgl_init_backend();
+    #endif
     const char *cwd = ".";
     if (!check_disk_space(cwd)) {
         fprintf(stderr, "Error - insufficient disk space to run Red Alert.\n");

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -90,3 +90,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Deleted obsolete `#pragma warning` directives in headers and verified `watcom.h` is no longer included.
 - LVGL is now built from the bundled submodule and linked when `USE_LVGL` is enabled.
 - Added a minimal `lv_conf.h` to configure the LVGL build.
+- LVGL initialization now occurs before other subsystems. `launch_main` and WinMain call `lv_init()` and `lvgl_init_backend()` and the main loop pumps events via `lv_timer_handler()`.


### PR DESCRIPTION
## Summary
- set up an SDL display backend for LVGL
- init LVGL at the start of `launch_main` and `WinMain`
- process LVGL timers in the game loop
- load the LVGL canvas immediately when created
- document the new initialization flow

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: invalid syntax in WINASM.ASM)*
- `ctest --output-on-failure` *(fails: unable to find executable due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_6852de3cd0c0832587a21f2890013300