### PR TITLE
Document LV_BACKEND backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,21 @@ Rendering can happen through three different routines depending on the platform 
 ## LVGL canvas output
 
 An experimental LVGL canvas can replace DirectDraw during the launcher.
-Fetch the submodule and compile with the option enabled:
+Fetch the submodule and compile with the option enabled.
+The launcher reads the `LV_BACKEND` environment variable at runtime and
+defaults to `x11`.  Available backend names are `x11`, `wayland`,
+`fbdev`, and `sdl`:
 
 ```sh
-export LV_BACKEND=x11        # default backend; change as needed
 git submodule update --init src/lvgl
 cp src/lvgl/lv_conf_template.h lv_conf.h    # basic configuration
 cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11" -DUSE_LVGL=ON
 cmake --build build
-./build/redalert
+LV_BACKEND=x11 ./build/redalert
 ```
+
+For example, to launch with the Wayland backend run `LV_BACKEND=wayland
+./build/redalert`.
 
 The launcher boots into the first menu using the selected LVGL backend.
 
@@ -87,5 +92,6 @@ Compilation currently fails because of missing dependencies and obsolete pragmas
 
 - [KEYBOARD.md](KEYBOARD.md) – keyboard queue and LVGL keyboard notes.
 - [MOUSE.md](MOUSE.md) – mouse handler and LVGL input device notes.
-The input driver defaults to the **x11** backend. Set `LV_BACKEND`
-before running the launcher to select another backend.
+The input driver defaults to the **x11** backend. Set `LV_BACKEND` to
+`wayland`, `fbdev`, or `sdl` before running the launcher to select a
+different backend.


### PR DESCRIPTION
## Summary
- document available LVGL backends in README
- mention that the launcher checks `LV_BACKEND` at runtime
- show an example of choosing a backend

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: invalid syntax in WINASM.ASM)*
- `ctest --output-on-failure` *(fails: executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f6d2065c8325a13fd0eb222eac4d