### PR TITLE
Add LVGL backend selection

### DIFF
--- a/CODE/lvgl/lvgl_backend.c
+++ b/CODE/lvgl/lvgl_backend.c
@@ -2,13 +2,62 @@
 #include "../../src/lvgl/src/lvgl.h"
 #include "../../src/lvgl/src/drivers/lv_drivers.h"
 #include "../externs.h" /* for ScreenWidth/ScreenHeight */
+#include <stdlib.h>
+#include <string.h>
 
 void lvgl_init_backend(void)
 {
-    lv_display_t *disp = lv_sdl_window_create(ScreenWidth, ScreenHeight);
-    lv_sdl_mouse_create();
-    lv_sdl_mousewheel_create();
-    lv_sdl_keyboard_create();
+    const char *name = getenv("LV_BACKEND");
+    if(!name || *name == '\0') name = "x11";
+
+    lv_backend_t backend = LV_BACKEND_UNKNOWN;
+    if(strcasecmp(name, "sdl") == 0) backend = LV_BACKEND_SDL;
+    else if(strcasecmp(name, "x11") == 0) backend = LV_BACKEND_X11;
+    else if(strcasecmp(name, "wayland") == 0) backend = LV_BACKEND_WAYLAND;
+    else if(strcasecmp(name, "fbdev") == 0) backend = LV_BACKEND_FBDEV;
+
+    lv_display_t *disp = NULL;
+
+    switch(backend) {
+    case LV_BACKEND_WAYLAND:
+        disp = lv_wayland_window_create(ScreenWidth, ScreenHeight, "Red Alert", NULL);
+        break;
+    case LV_BACKEND_FBDEV:
+        disp = lv_linux_fbdev_create();
+        if(disp) lv_linux_fbdev_set_file(disp, "/dev/fb0");
+        break;
+    case LV_BACKEND_X11:
+        disp = lv_x11_window_create("Red Alert", ScreenWidth, ScreenHeight);
+        if(disp) lv_x11_inputs_create(disp, NULL);
+        break;
+    case LV_BACKEND_SDL:
+        disp = lv_sdl_window_create(ScreenWidth, ScreenHeight);
+        if(disp) {
+            lv_sdl_mouse_create();
+            lv_sdl_mousewheel_create();
+            lv_sdl_keyboard_create();
+        }
+        break;
+    default:
+        break;
+    }
+
+    if(!disp) {
+        LV_LOG_WARN("Unknown LV_BACKEND '%s', falling back to SDL", name);
+        disp = lv_sdl_window_create(ScreenWidth, ScreenHeight);
+        if(disp) {
+            lv_sdl_mouse_create();
+            lv_sdl_mousewheel_create();
+            lv_sdl_keyboard_create();
+        }
+        name = "sdl";
+    }
+
     lv_display_set_default(disp);
-    lv_sdl_window_set_title(disp, "Red Alert");
+
+    if(strcmp(name, "sdl") == 0) {
+        lv_sdl_window_set_title(disp, "Red Alert");
+    }
+
+    LV_LOG_INFO("LVGL backend: %s", name);
 }

--- a/CODE/lvgl/lvgl_backend.h
+++ b/CODE/lvgl/lvgl_backend.h
@@ -5,6 +5,14 @@
 extern "C" {
 #endif
 
+typedef enum {
+    LV_BACKEND_SDL,
+    LV_BACKEND_X11,
+    LV_BACKEND_WAYLAND,
+    LV_BACKEND_FBDEV,
+    LV_BACKEND_UNKNOWN
+} lv_backend_t;
+
 void lvgl_init_backend(void);
 
 #ifdef __cplusplus

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -91,3 +91,5 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - LVGL is now built from the bundled submodule and linked when `USE_LVGL` is enabled.
 - Added a minimal `lv_conf.h` to configure the LVGL build.
 - LVGL initialization now occurs before other subsystems. `launch_main` and WinMain call `lv_init()` and `lvgl_init_backend()` and the main loop pumps events via `lv_timer_handler()`.
+- `lvgl_init_backend` now selects the display driver based on the `LV_BACKEND`
+  environment variable and falls back to SDL when unknown.


### PR DESCRIPTION
## Summary
- support selecting LVGL backend via `LV_BACKEND` env var
- log which backend was chosen
- update progress notes

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: invalid assembly syntax)*
- `ctest --output-on-failure` *(fails: unable to find executable)*

------
https://chatgpt.com/codex/tasks/task_e_6852f69d23508325a9a8ed2827716e8f