### PR TITLE
Improve LVGL backend error handling

### DIFF
--- a/CODE/STARTUP.CPP
+++ b/CODE/STARTUP.CPP
@@ -121,7 +121,9 @@ int main(int argc, char * argv[])
 LOG_CALL("%s entered\n", __func__);
 #ifdef USE_LVGL
     lv_init();
-    lvgl_init_backend();
+    if(lvgl_init_backend() != 0) {
+        return 1;
+    }
 #endif
 
 	#ifndef MPEGMOVIE // Denzil 6/10/98

--- a/CODE/lvgl/lvgl_backend.c
+++ b/CODE/lvgl/lvgl_backend.c
@@ -1,14 +1,39 @@
 #include "lvgl_backend.h"
 #include "../../src/lvgl/src/lvgl.h"
 #include "../../src/lvgl/src/drivers/lv_drivers.h"
+#include "../debug_log.h"
 #include "../externs.h" /* for ScreenWidth/ScreenHeight */
 
-void lvgl_init_backend(void)
+int lvgl_init_backend(void)
 {
-    lv_display_t *disp = lv_sdl_window_create(ScreenWidth, ScreenHeight);
-    lv_sdl_mouse_create();
-    lv_sdl_mousewheel_create();
-    lv_sdl_keyboard_create();
+    lv_display_t *disp = NULL;
+
+#if LV_USE_SDL
+    disp = lv_sdl_window_create(ScreenWidth, ScreenHeight);
+    if(!disp) {
+        LOG_MSG("lv_sdl_window_create failed\n");
+    } else {
+        lv_sdl_mouse_create();
+        lv_sdl_mousewheel_create();
+        lv_sdl_keyboard_create();
+        lv_sdl_window_set_title(disp, "Red Alert");
+    }
+#endif
+
+#if LV_USE_WAYLAND
+    if(disp == NULL) {
+        disp = lv_wayland_window_create(ScreenWidth, ScreenHeight, "Red Alert", NULL);
+        if(!disp) {
+            LOG_MSG("lv_wayland_window_create failed\n");
+        }
+    }
+#endif
+
+    if(!disp) {
+        LOG_MSG("LVGL backend initialization failed\n");
+        return -1;
+    }
+
     lv_display_set_default(disp);
-    lv_sdl_window_set_title(disp, "Red Alert");
+    return 0;
 }

--- a/CODE/lvgl/lvgl_backend.h
+++ b/CODE/lvgl/lvgl_backend.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void lvgl_init_backend(void);
+int lvgl_init_backend(void);
 
 #ifdef __cplusplus
 }

--- a/LAUNCH/main.c
+++ b/LAUNCH/main.c
@@ -59,10 +59,12 @@ static void delete_swaps(const char *path)
 
 int launch_main(int argc, char **argv)
 {
-    #ifdef USE_LVGL
+#ifdef USE_LVGL
     lv_init();
-    lvgl_init_backend();
-    #endif
+    if(lvgl_init_backend() != 0) {
+        return 1;
+    }
+#endif
     const char *cwd = ".";
     if (!check_disk_space(cwd)) {
         fprintf(stderr, "Error - insufficient disk space to run Red Alert.\n");

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -91,3 +91,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - LVGL is now built from the bundled submodule and linked when `USE_LVGL` is enabled.
 - Added a minimal `lv_conf.h` to configure the LVGL build.
 - LVGL initialization now occurs before other subsystems. `launch_main` and WinMain call `lv_init()` and `lvgl_init_backend()` and the main loop pumps events via `lv_timer_handler()`.
+- `lvgl_init_backend` now logs display creation failures, falls back to the Wayland backend when SDL is unavailable and returns a status code so callers can exit gracefully.


### PR DESCRIPTION
## Summary
- log LVGL display creation failures
- try a Wayland window if SDL fails
- return status from `lvgl_init_backend`
- exit early on backend failure
- document new LVGL behavior

## Testing
- `cmake -S . -B build -DUSE_LVGL=ON -DENABLE_ASM=OFF`
- `cmake --build build --target ipx_stub_test`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6852f6e16b8c8325b2eb3d6cddb67cb0