### PR TITLE
Pump lv_timer_handler in menu loops

### DIFF
--- a/CODE/INIT.CPP
+++ b/CODE/INIT.CPP
@@ -359,8 +359,11 @@ LOG_CALL("%s entered\n", __func__);
 		Fancy_Text_Print(TXT_STAND_BY, 160*RESFACTOR, 120*RESFACTOR, &ColorRemaps[PCOLOR_DIALOG_BLUE], TBLACK, TPF_CENTER|TPF_TEXT|TPF_DROPSHADOW);
 		Show_Mouse();
 
-		CCPalette.Set(FADE_PALETTE_SLOW);
-		Call_Back();
+                CCPalette.Set(FADE_PALETTE_SLOW);
+                        Call_Back();
+#ifdef USE_LVGL
+                        lv_timer_handler();
+#endif
 	}
 
 	/*
@@ -679,9 +682,12 @@ bool Select_Game(bool fade)
 #endif
 				selection = Main_Menu(ATTRACT_MODE_TIMEOUT);
 			}
-			Call_Back();
+                        Call_Back();
+#ifdef USE_LVGL
+                        lv_timer_handler();
+#endif
 
-			switch (selection) {
+                        switch (selection) {
 
 				/*
 				**	Pick an expansion scenario.

--- a/CODE/STARTUP.CPP
+++ b/CODE/STARTUP.CPP
@@ -671,10 +671,13 @@ LOG_CALL("%s entered\n", __func__);
 			/*
 			** Wait until the message handler has dealt with the message
 			*/
-			do
-			{
-				Keyboard->Check();
-			}while (ReadyToQuit == 1);
+                        do
+                        {
+                                Keyboard->Check();
+#ifdef USE_LVGL
+                                lv_timer_handler();
+#endif
+                        }while (ReadyToQuit == 1);
 
 			return (EXIT_SUCCESS);
 
@@ -940,10 +943,13 @@ void Emergency_Exit ( int code )
 	/*
 	** Wait until the message handler has dealt with the message
 	*/
-	do
-	{
-		Keyboard->Check();
-	}while (ReadyToQuit == 3);
+        do
+        {
+                Keyboard->Check();
+#ifdef USE_LVGL
+                lv_timer_handler();
+#endif
+        }while (ReadyToQuit == 3);
 
 
 #else	//WIN32

--- a/CODE/WINSTUB.CPP
+++ b/CODE/WINSTUB.CPP
@@ -122,13 +122,16 @@ void Check_For_Focus_Loss(void)
 
 	if ( !GameInFocus ) {
 		Focus_Loss();
-		while ( PeekMessage( &msg, NULL, 0, 0, PM_NOREMOVE | PM_NOYIELD ) ) {
-	  		if (!GetMessage( &msg, NULL, 0, 0 ) ) {
-				return;
-			}
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-		}
+                while ( PeekMessage( &msg, NULL, 0, 0, PM_NOREMOVE | PM_NOYIELD ) ) {
+                        if (!GetMessage( &msg, NULL, 0, 0 ) ) {
+                                return;
+                        }
+                        TranslateMessage(&msg);
+                        DispatchMessage(&msg);
+#ifdef USE_LVGL
+                        lv_timer_handler();
+#endif
+                }
 	}
 
 	if (!focus_last_time && GameInFocus) {
@@ -137,16 +140,19 @@ void Check_For_Focus_Loss(void)
 		CountDownTimerClass cd;
 		cd.Set(60*1);
 
-		do {
-			while (PeekMessage( &msg, NULL, 0, 0, PM_NOREMOVE )) {
-	  			if (!GetMessage( &msg, NULL, 0, 0 ) ) {
-					return;
-				}
-				TranslateMessage(&msg);
-				DispatchMessage(&msg);
-			}
+                do {
+                        while (PeekMessage( &msg, NULL, 0, 0, PM_NOREMOVE )) {
+                                if (!GetMessage( &msg, NULL, 0, 0 ) ) {
+                                        return;
+                                }
+                                TranslateMessage(&msg);
+                                DispatchMessage(&msg);
+#ifdef USE_LVGL
+                                lv_timer_handler();
+#endif
+                        }
 
-		} while (cd.Time());
+                } while (cd.Time());
 		VQA_ResumeAudio();
 		PostMessage (MainWindow, CCFocusMessage, 0, 0);
 //		AllSurfaces.Restore_Surfaces();
@@ -510,11 +516,14 @@ void Window_Dialog_Box(HANDLE  hinst, LPCTSTR  lpszTemplate, HWND  hwndOwner, DL
 	** until the dialog box is closed.
 	*/
 
-	DialogBox(hinst, lpszTemplate, hwndOwner, dlgprc);
-	while (GetMessage(&msg, NULL, 0, 0) && !AllDone) {
-		TranslateMessage(&msg);
-		DispatchMessage(&msg);
-	}
+        DialogBox(hinst, lpszTemplate, hwndOwner, dlgprc);
+        while (GetMessage(&msg, NULL, 0, 0) && !AllDone) {
+                TranslateMessage(&msg);
+                DispatchMessage(&msg);
+#ifdef USE_LVGL
+                lv_timer_handler();
+#endif
+        }
 
 	/*
 	** Restore the westwood mouse cursor and get rid of the windows one
@@ -797,11 +806,14 @@ void Memory_Error_Handler(void)
 
 	ReadyToQuit = 1;
 
-	PostMessage(MainWindow, WM_DESTROY, 0, 0);
-	do
-	{
-		Keyboard->Check();
-	}while (ReadyToQuit == 1);
+        PostMessage(MainWindow, WM_DESTROY, 0, 0);
+        do
+        {
+                Keyboard->Check();
+#ifdef USE_LVGL
+                lv_timer_handler();
+#endif
+        }while (ReadyToQuit == 1);
 
 	ExitProcess(0);
 }

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -91,3 +91,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - LVGL is now built from the bundled submodule and linked when `USE_LVGL` is enabled.
 - Added a minimal `lv_conf.h` to configure the LVGL build.
 - LVGL initialization now occurs before other subsystems. `launch_main` and WinMain call `lv_init()` and `lvgl_init_backend()` and the main loop pumps events via `lv_timer_handler()`.
+- Pre-game menus now call `lv_timer_handler()` within their loops so LVGL input devices stay responsive.


### PR DESCRIPTION
## Summary
- keep LVGL responsive during title screen caching
- pump LVGL in main menu loop
- run the timer handler when exiting via STARTUP and WinStub loops
- document LVGL menu responsiveness

## Testing
- `cmake -S . -B build -DUSE_LVGL=ON` *(passes)*
- `cmake --build build` *(fails: WINASM.ASM errors)*
- `ctest --test-dir build` *(fails: test executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852f716588c8325b16be49a5e767d44