### PR TITLE
Add X11 CI workflow

### DIFF
--- a/.github/workflows/x11_build.yml
+++ b/.github/workflows/x11_build.yml
@@ -1,0 +1,25 @@
+name: Build (X11)
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake nasm libx11-dev libxext-dev
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11" -DUSE_LVGL=ON -DLVGL_BACKEND=x11
+      - name: Build
+        run: cmake --build build -j $(nproc)
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure
+


### PR DESCRIPTION
## Summary
- build the game with LVGL X11 backend on Ubuntu
- run test suite

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11" -DUSE_LVGL=ON -DLVGL_BACKEND=x11 -DENABLE_ASM=OFF`
- `cmake --build build` *(fails: ignoring `#pragma` and missing `phone.h`)*
- `ctest --test-dir build` *(fails: Unable to find executable)*

------
https://chatgpt.com/codex/tasks/task_e_6853112a21f88325a716b90986ebeba5