### PR TITLE
Add riscv32 X11 build workflow

### DIFF
--- a/.github/workflows/riscv32.yml
+++ b/.github/workflows/riscv32.yml
@@ -1,0 +1,30 @@
+name: riscv32-x11
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cross compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build gcc-riscv64-linux-gnu g++-riscv64-linux-gnu
+
+      - name: Configure CMake
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_C_COMPILER=riscv64-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=riscv64-linux-gnu-g++ \
+            -DCMAKE_C_FLAGS="-march=rv32ima -mabi=ilp32" \
+            -DCMAKE_CXX_FLAGS="-march=rv32ima -mabi=ilp32" \
+            -DBUILD_TESTING=OFF -DUSE_LVGL=ON -DLVGL_BACKEND=x11
+
+      - name: Build
+        run: cmake --build build

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -106,3 +106,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
   palette from `CurrentPalette`.
 - Menu processing loops now call `lv_timer_handler()` so LVGL widgets stay
   responsive while waiting for user input.
+- Added a GitHub action that cross compiles the project for the RV32IMA ILP32 architecture using the X11 backend.


### PR DESCRIPTION
## Summary
- set up a GitHub Actions workflow that cross compiles using the rv32ima ILP32 ABI
- log this new workflow in `PROGRESS.md`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: invalid syntax in WINASM.ASM)*

------
https://chatgpt.com/codex/tasks/task_e_6853117457d08325818971410349766c