### PR TITLE
Replace remaining debug assembly with C stubs

### DIFF
--- a/CODE/CMakeLists.txt
+++ b/CODE/CMakeLists.txt
@@ -316,7 +316,8 @@ if(NOT ENABLE_ASM)
     list(APPEND CODE_SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/../src/cpuid.c"
         "${CMAKE_SOURCE_DIR}/src/support.c"
-        "${CMAKE_SOURCE_DIR}/src/support_stub.c")
+        "${CMAKE_SOURCE_DIR}/src/support_stub.c"
+        "${CMAKE_SOURCE_DIR}/src/debug/asm_replacements.c")
     list(REMOVE_ITEM CODE_ASM
         "${CMAKE_CURRENT_LIST_DIR}/CPUID.ASM"
         "${CMAKE_CURRENT_LIST_DIR}/COORDA.ASM"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -112,4 +112,8 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Replaced `LCWCOMP.ASM` with a portable C implementation when `ENABLE_ASM`
   is disabled.
 - Added a GitHub action that cross compiles the project for the RV32IMA ILP32 architecture using the X11 backend.
-- Added C replacements for Mem_Copy, Largest_Mem_Block and page-in helpers. 
+- Added C replacements for Mem_Copy, Largest_Mem_Block and page-in helpers.
+- Ported the remaining debug and tool assembly modules to portable C
+  (`src/debug/asm_replacements.c` and `tools/audiomak/scode.c`).
+  The build now omits `WIN32LIB/SRCDEBUG` and `TOOLS/AUDIOMAK/SCODE.ASM`
+  entirely when `ENABLE_ASM` is off.

--- a/src/debug/asm_replacements.c
+++ b/src/debug/asm_replacements.c
@@ -1,0 +1,162 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cpuid.h>
+#include "debug_log.h"
+
+unsigned char Random(void)
+{
+    LOG_CALL("Random C replacement\n");
+    return (unsigned char)(rand() & 0xFF);
+}
+
+int Get_Random_Mask(int maxval)
+{
+    LOG_CALL("Get_Random_Mask C replacement\n");
+    if (maxval <= 0)
+        return 1;
+    unsigned mask = 1;
+    while (mask <= (unsigned)maxval)
+        mask <<= 1;
+    return (int)(mask - 1);
+}
+
+void Shake_Screen(int shakes)
+{
+    LOG_CALL("Shake_Screen stub\n");
+    (void)shakes;
+}
+
+long Reverse_Long(long number)
+{
+    LOG_CALL("Reverse_Long C replacement\n");
+    uint32_t n = (uint32_t)number;
+    n = ((n & 0x00FF00FFu) << 8) | ((n & 0xFF00FF00u) >> 8);
+    return (long)((n >> 16) | (n << 16));
+}
+
+short Reverse_Short(short number)
+{
+    LOG_CALL("Reverse_Short C replacement\n");
+    uint16_t n = (uint16_t)number;
+    n = (uint16_t)((n >> 8) | (n << 8));
+    return (short)n;
+}
+
+long Swap_Long(long number)
+{
+    LOG_CALL("Swap_Long C replacement\n");
+    uint32_t n = (uint32_t)number;
+    return (long)((n >> 16) | (n << 16));
+}
+
+long Calculate_CRC(void *buffer, long length)
+{
+    LOG_CALL("Calculate_CRC C replacement\n");
+    uint8_t *ptr = (uint8_t *)buffer;
+    uint32_t crc = 0;
+    while (length >= 4) {
+        uint32_t val;
+        memcpy(&val, ptr, 4);
+        crc = (crc << 1) | (crc >> 31);
+        crc += val;
+        ptr += 4;
+        length -= 4;
+    }
+    if (length) {
+        uint32_t val = 0;
+        for (int i = 0; i < length; ++i) {
+            val |= (uint32_t)ptr[i] << (i * 8);
+        }
+        crc = (crc << 1) | (crc >> 31);
+        crc += val;
+    }
+    return (long)crc;
+}
+
+static unsigned cpu_family(void)
+{
+    unsigned eax, ebx, ecx, edx;
+    if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx))
+        return 3; /* 386 */
+    return (eax >> 8) & 0xF;
+}
+
+uint16_t Processor(void)
+{
+    LOG_CALL("Processor C replacement\n");
+    unsigned fam = cpu_family();
+    if (fam <= 3)
+        return 0; /* 386 */
+    if (fam == 4)
+        return 1; /* 486 */
+    return 2;      /* Pentium or newer */
+}
+
+uint16_t Operating_System(void)
+{
+    LOG_CALL("Operating_System stub\n");
+    return 1; /* DOS */
+}
+
+unsigned long random(unsigned long mod)
+{
+    LOG_CALL("random C replacement\n");
+    if (mod == 0)
+        return 0;
+    return (unsigned long)(rand() % mod);
+}
+
+int Clip_Rect(int *x, int *y, int *dw, int *dh, int width, int height)
+{
+    LOG_CALL("Clip_Rect C replacement\n");
+    if (!x || !y || !dw || !dh)
+        return -1;
+    int clipped = 0;
+    if (*dw <= 0 || *dh <= 0)
+        return -1;
+    if (*x < 0) {
+        *dw += *x;
+        *x = 0;
+        clipped = 1;
+    }
+    if (*y < 0) {
+        *dh += *y;
+        *y = 0;
+        clipped = 1;
+    }
+    if (*x + *dw > width) {
+        *dw = width - *x;
+        clipped = 1;
+    }
+    if (*y + *dh > height) {
+        *dh = height - *y;
+        clipped = 1;
+    }
+    if (*dw <= 0 || *dh <= 0)
+        return -1;
+    return clipped;
+}
+
+int Confine_Rect(int *x, int *y, int dw, int dh, int width, int height)
+{
+    LOG_CALL("Confine_Rect C replacement\n");
+    if (!x || !y)
+        return -1;
+    int moved = 0;
+    if (*x < 0) {
+        *x = 0;
+        moved = 1;
+    } else if (*x + dw > width) {
+        *x = width - dw;
+        moved = 1;
+    }
+    if (*y < 0) {
+        *y = 0;
+        moved = 1;
+    } else if (*y + dh > height) {
+        *y = height - dh;
+        moved = 1;
+    }
+    return moved;
+}

--- a/tools/audiomak/scode.c
+++ b/tools/audiomak/scode.c
@@ -1,0 +1,76 @@
+#include <stdint.h>
+#include <string.h>
+#include "debug_log.h"
+
+static const int8_t bit2_table[4]  = { -2, -1, 0, 1 };
+static const int8_t bit4_table[16] = { -9,-8,-6,-5,-4,-3,-2,-1,0,1,2,3,4,5,6,8 };
+
+long Decompress_Frame(void *source, void *dest, long size)
+{
+    LOG_CALL("Decompress_Frame tool C version\n");
+    uint8_t *s = (uint8_t *)source;
+    uint8_t *d = (uint8_t *)dest;
+    int previous = 0x80;
+    long consumed = 0;
+
+    while (size > 0) {
+        uint8_t code = *s++;
+        int count = (code & 0x3F) + 1;
+        consumed++;
+
+        switch (code >> 6) {
+        case 0:
+            if ((count - 1) & 0x20) {
+                int delta = (count - 1) & 0x1F;
+                if (delta & 0x10) delta |= 0xFFE0;
+                previous += delta;
+                if (previous < 0) previous = 0; else if (previous > 255) previous = 255;
+                *d++ = (uint8_t)previous;
+                size--;
+            } else {
+                if (count > size) count = (int)size;
+                memcpy(d, s, count);
+                consumed += count;
+                d += count;
+                s += count;
+                size -= count;
+                previous = d[-1];
+            }
+            break;
+        case 1:
+            while (count-- && size >= 2) {
+                uint8_t delta = *s++;
+                consumed--;
+                previous += bit4_table[delta & 0x0F];
+                if (previous < 0) previous = 0; else if (previous > 255) previous = 255;
+                *d++ = (uint8_t)previous;
+                size--;
+                previous += bit4_table[(delta >> 4) & 0x0F];
+                if (previous < 0) previous = 0; else if (previous > 255) previous = 255;
+                *d++ = (uint8_t)previous;
+                size--;
+            }
+            break;
+        case 2:
+            while (count-- && size >= 4) {
+                uint8_t delta = *s++;
+                consumed--;
+                for (int i = 0; i < 4; ++i) {
+                    previous += bit2_table[(delta >> (i*2)) & 3];
+                    if (previous < 0) previous = 0; else if (previous > 255) previous = 255;
+                    *d++ = (uint8_t)previous;
+                    size--;
+                }
+            }
+            break;
+        default:
+            if (count > size) count = (int)size;
+            memset(d, (uint8_t)previous, count);
+            d += count;
+            size -= count;
+            break;
+        }
+    }
+
+    return consumed;
+}


### PR DESCRIPTION
## Summary
- reimplement remaining debug/utility assembly in portable C
- compile the C sources instead of assembly when ENABLE_ASM=OFF
- document final removal of SRCDEBUG and tool asm

## Testing
- `cmake -S . -B build`
- `cmake -S . -B build -DENABLE_ASM=OFF`
- `cmake --build build -j $(nproc)` *(fails: `vq.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68531a8b3dfc83258b15912779108169