### PR TITLE
Add missing phone.h

### DIFF
--- a/CODE/phone.h
+++ b/CODE/phone.h
@@ -1,0 +1,66 @@
+//
+// Copyright 2020 Electronic Arts Inc.
+//
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free 
+// software: you can redistribute it and/or modify it under the terms of 
+// the GNU General Public License as published by the Free Software Foundation, 
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed 
+// in the hope that it will be useful, but with permitted additional restrictions 
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT 
+// distributed with this program. You should have received a copy of the 
+// GNU General Public License along with permitted additional restrictions 
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+
+/* $Header:   F:\projects\c&c\vcs\code\phone.h_v   1.9   16 Oct 1995 16:47:58   JOE_BOSTIC  $ */
+/*************************************************************************** 
+ *                                                                         * 
+ *                 Project Name : Command & Conquer                        * 
+ *                                                                         * 
+ *                    File Name : PHONE.H                                  * 
+ *                                                                         * 
+ *                   Programmer : Bill R. Randolph                         * 
+ *                                                                         * 
+ *                   Start Date : 04/28/95                                 * 
+ *                                                                         * 
+ *                  Last Update : April 28, 1995 [BRR]                     * 
+ *                                                                         * 
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef PHONE_H
+#define PHONE_H
+
+/*
+***************************** Class Declaration *****************************
+*/
+class PhoneEntryClass
+{
+	public:
+		enum PhoneEntryEnum {
+			PHONE_MAX_NAME = 21,
+			PHONE_MAX_NUM = 21
+		};
+
+		PhoneEntryClass(void) {};
+		~PhoneEntryClass() {};
+
+		operator == (PhoneEntryClass &obj) 
+			{ return (memcmp (Name,obj.Name,strlen(Name))==0);}
+		operator != (PhoneEntryClass &obj)
+			{ return (memcmp (Name,obj.Name,strlen(Name))!=0);}
+		operator > (PhoneEntryClass &obj)
+			{ return (memcmp(Name, obj.Name, strlen(Name)) > 0);}
+		operator < (PhoneEntryClass &obj)
+			{ return (memcmp(Name, obj.Name, strlen(Name)) < 0);}
+		operator >= (PhoneEntryClass &obj)
+			{ return (memcmp(Name, obj.Name, strlen(Name)) >= 0);}
+		operator <= (PhoneEntryClass &obj)
+			{ return (memcmp(Name, obj.Name, strlen(Name)) <= 0);}
+
+		SerialSettingsType Settings;
+		char Name[ PHONE_MAX_NAME ];		// destination person's name
+		char Number[ PHONE_MAX_NUM ];		// phone #
+};
+
+#endif

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -114,3 +114,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Added a GitHub action that cross compiles the project for the RV32IMA ILP32 architecture using the X11 backend.
 - Added C replacements for Mem_Copy, Largest_Mem_Block and page-in helpers. 
 - Converted Westwood and HMI ADPCM assembly decompressors to C and compile them when ENABLE_ASM is off.
+- Retrieved missing `phone.h` header from the TiberianDawn repository so network and phonebook code can compile.


### PR DESCRIPTION
## Summary
- retrieve `phone.h` from the TiberianDawn repo
- document the new header in `PROGRESS.md`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: invalid syntax in WINASM.ASM)*
- `ctest --output-on-failure` *(fails: executables not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531e1bc7488325b7e31b16e0b9bdc1