### PR TITLE
Fix VQ headers include path

### DIFF
--- a/VQ/VQA32/CMakeLists.txt
+++ b/VQ/VQA32/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(vqa32 STATIC ${VQA32_SOURCES})
   target_include_directories(vqa32 PUBLIC
       ${CMAKE_CURRENT_LIST_DIR}
       ${CMAKE_CURRENT_LIST_DIR}/..
+      ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
       ${CMAKE_CURRENT_LIST_DIR}/../VQM32
       "${CMAKE_SOURCE_DIR}"
   )


### PR DESCRIPTION
## Summary
- add missing include directory for VQA32 sources so vq.h resolves

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)` *(fails: `CONFIG.CPP` invalid conversions)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68533314bd448325a6746292c93e703a