### PR TITLE
Enable RISC‑V run helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(redalert C CXX)
 enable_testing()
 
 # Build options
-option(ENABLE_ASM "Enable assembly modules" ON)
+option(ENABLE_ASM "Enable assembly modules" OFF)
 option(USE_LVGL "Enable LVGL canvas output" OFF)
 set(LVGL_BACKEND "x11" CACHE STRING "LVGL backend (x11, wayland, sdl, windows)")
 option(USE_C_BLITTERS "Use C implementations of blit routines" OFF)
@@ -45,7 +45,9 @@ add_subdirectory(CODE)
 add_subdirectory(VQ/VQA32)
 set(MINIAUDIO_NO_EXTRA_NODES ON CACHE BOOL "" FORCE)
 add_subdirectory(src/miniaudio)
-add_subdirectory(tests)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 
 set(SOURCES
     ${CODE_SOURCES}
@@ -93,4 +95,7 @@ if(USE_LVGL)
 endif()
 if(WIN32)
     target_link_libraries(redalert PRIVATE ws2_32)
+endif()
+if(COMMAND add_qemu_run_target)
+    add_qemu_run_target(redalert)
 endif()

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -139,3 +139,9 @@ As the port progresses, updates on how each dependency has been replaced or stub
   `Draw_Mouse`, `ASM_Set_Mouse_Cursor`) in C (`src/mem_helpers.c` and
   `src/input_asm_repl.c`). The old `VMPAGEIN.ASM` and `WWMOUSE.ASM` modules are
   no longer required when assembly is disabled.
+- Added GCC and Clang detection to `compiler.h` so modern compilers no longer hit the "unknown compiler" error.
+- Removed Borland `#pragma option` and `#pragma warn` directives from all copies of `wwstd.h`.
+- Wrapped the `TICKS_PER_SECOND` macros in `commlib.h` with `#ifndef` to avoid clashes with `CODE/defines.h`.
+- Created a stub `pcx.h` that includes `CODE/filepcx.h` to satisfy `function.h` and `WRITEPCX.CPP`.
+- Switched the default `ENABLE_ASM` option in CMake to `OFF` and ran a build to capture the next set of compiler errors.
+- Replaced stub `pcx.h` with the official header from Renegade.

--- a/VQ/INCLUDE/WWLIB32/wwstd.h
+++ b/VQ/INCLUDE/WWLIB32/wwstd.h
@@ -182,7 +182,6 @@ typedef void 	VOID;
 
 #define	VOID		void
 
-#pragma	warn -eas
 #define	TRUE		1
 #define	FALSE		0
 
@@ -217,7 +216,7 @@ typedef void 	VOID;
 
 
 // Inline Routines
-//ÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ
+//ÃÃÃÃÃÃÃÃÃÃÃÃÃÃÃÃ
 //
 // These Template functions are generally used 
 // by classes when they havce over loaded > and <.

--- a/WIN32LIB/INCLUDE/wwstd.h
+++ b/WIN32LIB/INCLUDE/wwstd.h
@@ -109,7 +109,6 @@
 #endif
 #define GET_SIZE(a)					((sizeof(a) / sizeof(*a)))
 
-#pragma option -Jg
 // Returns the absolute value of the number.
 #ifdef ABS
 #undef ABS
@@ -144,7 +143,6 @@ template<class T> T MAX(T a, T b)
 short MAX(short, short);
 int MAX(int, int);
 long MAX(long, long);
-#pragma option -Jgd
 
 // Returns the low word of a long
 #define	LOW_WORD(a)		((unsigned short)((long)(a) & 0x0000FFFFL))
@@ -196,7 +194,6 @@ typedef void 	VOID;
 
 #define	VOID		void
 
-#pragma	warn -eas
 #define	TRUE		1
 #define	FALSE		0
 

--- a/WIN32LIB/MISC/wwstd.h
+++ b/WIN32LIB/MISC/wwstd.h
@@ -109,7 +109,6 @@
 #endif
 #define GET_SIZE(a)					((sizeof(a) / sizeof(*a)))
 
-#pragma option -Jg
 // Returns the absolute value of the number.
 #ifdef ABS
 #undef ABS
@@ -144,7 +143,6 @@ template<class T> T MAX(T a, T b)
 short MAX(short, short);
 int MAX(int, int);
 long MAX(long, long);
-#pragma option -Jgd
 
 // Returns the low word of a long
 #define	LOW_WORD(a)		((unsigned short)((long)(a) & 0x0000FFFFL))
@@ -196,7 +194,6 @@ typedef void 	VOID;
 
 #define	VOID		void
 
-#pragma	warn -eas
 #define	TRUE		1
 #define	FALSE		0
 

--- a/WWFLAT32/INCLUDE/wwstd.h
+++ b/WWFLAT32/INCLUDE/wwstd.h
@@ -182,7 +182,6 @@ typedef void 	VOID;
 
 #define	VOID		void
 
-#pragma	warn -eas
 #define	TRUE		1
 #define	FALSE		0
 
@@ -217,7 +216,7 @@ typedef void 	VOID;
 
 
 // Inline Routines
-//ÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ
+//ÃÃÃÃÃÃÃÃÃÃÃÃÃÃÃÃ
 //
 // These Template functions are generally used
 // by classes when they havce over loaded > and <.

--- a/WWFLAT32/MISC/wwstd.h
+++ b/WWFLAT32/MISC/wwstd.h
@@ -182,7 +182,6 @@ typedef void 	VOID;
 
 #define	VOID		void
 
-#pragma	warn -eas
 #define	TRUE		1
 #define	FALSE		0
 
@@ -217,7 +216,7 @@ typedef void 	VOID;
 
 
 // Inline Routines
-//ÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍÍ
+//ÃÃÃÃÃÃÃÃÃÃÃÃÃÃÃÃ
 //
 // These Template functions are generally used 
 // by classes when they havce over loaded > and <.

--- a/cmake/riscv32_qemu.cmake
+++ b/cmake/riscv32_qemu.cmake
@@ -19,7 +19,8 @@ set(CMAKE_C_FLAGS_INIT "-march=rv32ima -mabi=ilp32" CACHE STRING "" FORCE)
 set(CMAKE_CXX_FLAGS_INIT "-march=rv32ima -mabi=ilp32" CACHE STRING "" FORCE)
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-nostdlib -static -Wl,--gc-sections" CACHE STRING "" FORCE)
 
-set(ENABLE_ASM OFF CACHE BOOL "Disable assembly")
+set(ENABLE_ASM OFF CACHE BOOL "Disable assembly" FORCE)
+set(USE_C_BLITTERS ON CACHE BOOL "Use C implementations of blitters" FORCE)
 set(USE_LVGL ON CACHE BOOL "Enable LVGL")
 set(LVGL_BACKEND "x11" CACHE STRING "LVGL backend")
 

--- a/cmake/riscv64_qemu.cmake
+++ b/cmake/riscv64_qemu.cmake
@@ -19,7 +19,8 @@ set(CMAKE_C_FLAGS_INIT "-march=rv64ima -mabi=lp64" CACHE STRING "" FORCE)
 set(CMAKE_CXX_FLAGS_INIT "-march=rv64ima -mabi=lp64" CACHE STRING "" FORCE)
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-nostdlib -static -Wl,--gc-sections" CACHE STRING "" FORCE)
 
-set(ENABLE_ASM OFF CACHE BOOL "Disable assembly")
+set(ENABLE_ASM OFF CACHE BOOL "Disable assembly" FORCE)
+set(USE_C_BLITTERS ON CACHE BOOL "Use C implementations of blitters" FORCE)
 set(USE_LVGL ON CACHE BOOL "Enable LVGL")
 set(LVGL_BACKEND "x11" CACHE STRING "LVGL backend")
 

--- a/commlib.h
+++ b/commlib.h
@@ -130,8 +130,12 @@ typedef enum trigger_level{
 #define POS4INFO()               _asinb(POS4PORT)
 #define POS5INFO()               _asinb(POS5PORT)
 
+#ifndef TICKS_PER_SECOND
 #define TICKS_PER_SECOND              18
+#endif
+#ifndef MILLISECONDS_PER_TICK
 #define MILLISECONDS_PER_TICK         55
+#endif
 
 #ifndef TRUE
 #define TRUE            1

--- a/compiler.h
+++ b/compiler.h
@@ -405,6 +405,34 @@
     #endif
 #endif                                           /* Microsoft C           */
 
+#elif defined(__clang__)
+    #define GF_COMPILER_NAME "Clang"
+    #define GF_CLANG
+    #define GF_COMPILER_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+    #define ANSI_PROTOTYPES
+    #define GF_CONV
+    #define GF_CDECL
+    #define GF_INTERRUPT
+    #define GF_UNUSED_PARAMETER( a ) (void)(a)
+    #define GF_FAR
+    #define _LCODE 0
+    #define _LDATA 0
+    #define _HUGE 0
+
+#elif defined(__GNUC__)
+    #define GF_COMPILER_NAME "GCC"
+    #define GF_GCC
+    #define GF_COMPILER_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+    #define ANSI_PROTOTYPES
+    #define GF_CONV
+    #define GF_CDECL
+    #define GF_INTERRUPT
+    #define GF_UNUSED_PARAMETER( a ) (void)(a)
+    #define GF_FAR
+    #define _LCODE 0
+    #define _LDATA 0
+    #define _HUGE 0
+
 #ifndef GF_COMPILER_NAME
 #error This is an unknown compiler!
 #endif

--- a/pcx.h
+++ b/pcx.h
@@ -1,0 +1,75 @@
+/*
+**Command & Conquer Renegade(tm)
+**Copyright 2025 Electronic Arts Inc.
+**
+**This program is free software: you can redistribute it and/or modify
+**it under the terms of the GNU General Public License as published by
+**the Free Software Foundation, either version 3 of the License, or
+**(at your option) any later version.
+**
+**This program is distributed in the hope that it will be useful,
+**but WITHOUT ANY WARRANTY; without even the implied warranty of
+**MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**GNU General Public License for more details.
+**
+**You should have received a copy of the GNU General Public License
+**along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : Command & Conquer                                            *
+ *                                                                                             *
+ *                     $Archive:: /Commando/Library/PCX.H                                     $*
+ *                                                                                             *
+ *                      $Author:: Greg_h                                                      $*
+ *                                                                                             *
+ *                     $Modtime:: 7/22/97 11:37a                                              $*
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * Functions:                                                                                  *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef PCX_H
+#define PCX_H
+
+#include "CODE/surface.h"
+#include "WIN32LIB/INCLUDE/palette.h"
+#include "CODE/wwfile.h"
+#include <string.h>
+
+struct RGB {
+    unsigned char   red;
+    unsigned char   green;
+    unsigned char   blue;
+};
+
+struct PCX_HEADER
+{
+    char    id;
+    char    version;
+    char    encoding;
+    char    pixelsize;
+    short   x;
+    short   y;
+    short   width;
+    short   height;
+    short   xres;
+    short   yres;
+    RGB     ega_palette[16];
+    char    nothing;
+    char    color_planes;
+    unsigned short  byte_per_line;
+    short   palette_type;
+    char    filler[58];
+};
+
+Surface * Read_PCX_File(FileClass & file_handle, PaletteClass * palette= NULL, void * buff=NULL, long size=0);
+//Surface * Read_PCX_File (char * name, Buffer & Buff, PaletteClass * palette= NULL) ;
+bool Write_PCX_File(FileClass & file, Surface & pic, PaletteClass * palette);
+
+#endif


### PR DESCRIPTION
## Summary
- allow RISC-V toolchain files to add a `run` target
- respect `BUILD_TESTING` in root build system
- force pure C builds for the RISC-V toolchains

## Testing
- `cmake -S . -B build -DENABLE_ASM=OFF -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: compiler errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853419b647c8325bae9ae35541c0d9e