### PR TITLE
Modernize commlib header

### DIFF
--- a/CODE/2KEYFRAM.CPP
+++ b/CODE/2KEYFRAM.CPP
@@ -40,6 +40,7 @@
 
 
 #include "function.h"
+#include "memflag.h"
 
 #define SUBFRAMEOFFS			7	// 3 1/2 frame offsets loaded (2 offsets/frame)
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -142,6 +142,9 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Added GCC and Clang detection to `compiler.h` so modern compilers no longer hit the "unknown compiler" error.
 - Removed Borland `#pragma option` and `#pragma warn` directives from all copies of `wwstd.h`.
 - Wrapped the `TICKS_PER_SECOND` macros in `commlib.h` with `#ifndef` to avoid clashes with `CODE/defines.h`.
+- Added fallback definitions for `GF_CONV`, `GF_CDECL`, `GF_DLL_FAR` and
+  `GF_FAR` in `commlib.h` so the file compiles cleanly with modern GCC and
+  Clang even when `compiler.h` does not provide them.
 - Created a stub `pcx.h` that includes `CODE/filepcx.h` to satisfy `function.h` and `WRITEPCX.CPP`.
 - Switched the default `ENABLE_ASM` option in CMake to `OFF` and ran a build to capture the next set of compiler errors.
 - Replaced stub `pcx.h` with the official header from Renegade.

--- a/commlib.h
+++ b/commlib.h
@@ -37,6 +37,18 @@
 #endif
 
 #include "compiler.h"
+#ifndef GF_CONV
+#define GF_CONV
+#endif
+#ifndef GF_CDECL
+#define GF_CDECL
+#endif
+#ifndef GF_DLL_FAR
+#define GF_DLL_FAR
+#endif
+#ifndef GF_FAR
+#define GF_FAR
+#endif
 #include "dosxptrs.h"
 #if defined( GF_WINDOWS ) || defined( GF_WIN32 )
 #include <windows.h>

--- a/compat.h
+++ b/compat.h
@@ -10,4 +10,20 @@
 #define strnicmp strncasecmp
 #endif
 
+#ifndef _MAX_FNAME
+#define _MAX_FNAME 256
+#endif
+#ifndef _MAX_EXT
+#define _MAX_EXT 256
+#endif
+#ifndef _MAX_PATH
+#define _MAX_PATH 260
+#endif
+#ifndef _MAX_DIR
+#define _MAX_DIR 256
+#endif
+#ifndef _MAX_DRIVE
+#define _MAX_DRIVE 3
+#endif
+
 #endif /* COMPAT_H */


### PR DESCRIPTION
## Summary
- ensure `commlib.h` defines calling convention macros when `compiler.h` doesn't
- document the update in `PROGRESS.md`
- include `memflag.h` in `2KEYFRAM.CPP`
- add compatibility constants to `compat.h`

## Testing
- `cmake .. -DENABLE_ASM=OFF`
- `make -j$(nproc)` *(fails: comparison and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68534632a7b4832587f006c4578274bd