### PR TITLE
Remove Watcom pragmas

### DIFF
--- a/CODE/queue.h
+++ b/CODE/queue.h
@@ -48,7 +48,8 @@
 #include	"target.h"
 #include	"defines.h"
 
-#pragma warn -inl
+/* Watcom specific warning control - not needed */
+/* #pragma warn -inl */
 
 /*
 **	This class implements a classic FIFO queue (also known as - standing in line). Objects

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -148,3 +148,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Created a stub `pcx.h` that includes `CODE/filepcx.h` to satisfy `function.h` and `WRITEPCX.CPP`.
 - Switched the default `ENABLE_ASM` option in CMake to `OFF` and ran a build to capture the next set of compiler errors.
 - Replaced stub `pcx.h` with the official header from Renegade.
+- Guarded obsolete pragma directives in `queue.h` and `memflag.h` so modern compilers ignore them.

--- a/WIN32LIB/INCLUDE/memflag.h
+++ b/WIN32LIB/INCLUDE/memflag.h
@@ -72,7 +72,9 @@ long	Ram_Free(MemoryFlagType flag);
 long	Heap_Size(MemoryFlagType flag);
 long	Total_Ram_Free(MemoryFlagType flag);
 
+#ifdef __WATCOMC__
 #pragma option -Jgd
+#endif
 
 inline void * operator new(size_t size, MemoryFlagType flag)
 {
@@ -83,7 +85,9 @@ inline void * operator new[] (size_t size, MemoryFlagType flag)
 	return(Alloc(size, flag));
 }
 
+#ifdef __WATCOMC__
 #pragma option -Jgd
+#endif
 
 /*=========================================================================*/
 /* The following prototypes are for the file: MEM_COPY.ASM						*/


### PR DESCRIPTION
## Summary
- disable old `#pragma warn` in `queue.h`
- guard `#pragma option -Jgd` directives in `memflag.h`
- note the change in `PROGRESS.md`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: expected build errors)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68534d0fbd708325b3866c4c8afc85ee