### PR TITLE
Add LVGL build helper script

### DIFF
--- a/tools/build_lvgl.sh
+++ b/tools/build_lvgl.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -e
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+mkdir -p "$repo_root/logs"
+cd "$repo_root"
+{
+    git submodule update --init src/lvgl
+    export BUILDLOGS=1
+    cmake -S . -B build -DPLATFORM=LVGL
+    cmake --build build
+} > "$repo_root/logs/platformLVGL.log" 2>&1


### PR DESCRIPTION
## Summary
- add `tools/build_lvgl.sh` for building the LVGL platform
- set `BUILDLOGS=1` to enable verbose compiler output

## Testing
- `./tools/build_lvgl.sh` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6853c2e440c883259e84a97c970cd4c9