### PR TITLE
Set global C++11 standard flag

### DIFF
--- a/cmake/base.cmake
+++ b/cmake/base.cmake
@@ -20,6 +20,8 @@ endif()
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_options(-Wall -Wextra -Werror)
 
 if(USE_LVGL)


### PR DESCRIPTION
## Summary
- enforce C++11 on all targets in `cmake/base.cmake`
- verify build system picks up `-std=gnu++11`

## Testing
- `cmake -S . -B build -DPLATFORM=LVGL`
- `grep -R -- "-std=" build | head`

------
https://chatgpt.com/codex/tasks/task_e_6853c6b314cc8325bfd34c98368761aa