### PR TITLE
Add LVGL build for VQ library

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -69,6 +69,7 @@ As the port progresses, updates on how each dependency has been replaced or stub
   for the original assembly routines.
 - Added stubs for missing <dos.h> and <pharlap.h> to keep the build going.
 - Removed legacy compiler pragmas and compiled VQA32 sources as C++.
+- Added CMake build for an LVGL variant (vqa32_lvgl) with C blitters and no assembly.
 - Created portable stubs for the Greenleaf serial functions in `fast.h` and `src/fast_stub.c`.
 - Updated legacy VQM headers to compile under C11 by defining the `cdecl` macro when missing.
 - Fixed remaining DOS path separators in VQM include files.

--- a/VQ/LVGL/CMakeLists.txt
+++ b/VQ/LVGL/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(VQLVGL_SOURCES
+    AUDIO.CPP
+    CAPTION.CPP
+    CONFIG.CPP
+    DRAWER.CPP
+    DSTREAM.CPP
+    LOADER.CPP
+    MONODISP.CPP
+    TASK.CPP
+    VERTAG.CPP
+)
+
+# Build the LVGL variant of the VQA player using the DOS sources.
+add_library(vqa32_lvgl STATIC ${VQLVGL_SOURCES})
+
+# Require C++11 for the playback library
+target_compile_features(vqa32_lvgl PUBLIC cxx_std_11)
+
+# Public include paths match the DOS version
+target_include_directories(vqa32_lvgl PUBLIC
+     ${CMAKE_CURRENT_LIST_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}/..
+     ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+     ${CMAKE_CURRENT_LIST_DIR}/../VQM32
+     "${CMAKE_SOURCE_DIR}"
+ )
+
+# Enable LVGL output and C blitters while leaving assembly disabled
+target_compile_definitions(vqa32_lvgl PUBLIC USE_LVGL)

--- a/cmake/base.cmake
+++ b/cmake/base.cmake
@@ -20,6 +20,8 @@ endif()
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_options(-Wall -Wextra -Werror)
 
 if(USE_LVGL)


### PR DESCRIPTION
## Summary
- add a CMakeLists to build VQ playback sources for LVGL
- note the LVGL variant in `PROGRESS.md`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: comparison of integer expressions of different signedness in ccptr.h)*
- `ctest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c5d8103883258358c70c7fd60b7b