### PR TITLE
Port LVGL playback code to C11

### DIFF
--- a/VQ/LVGL/AUDIO.c
+++ b/VQ/LVGL/AUDIO.c
@@ -61,7 +61,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <sys/time.h>
 #include "vqaplayp.h"
@@ -89,9 +88,9 @@
 
 #if(VQAAUDIO_ON)
 long AutoDetect(_SOS_CAPABILITIES *digicaps, long bitsize, long channels);
-void far TimerCallback(void);
-void far cdecl AudioCallback(WORD wDriverHandle, WORD wAction,
-		WORD wSampleID);
+void TimerCallback(void);
+void cdecl AudioCallback(WORD wDriverHandle, WORD wAction,
+                WORD wSampleID);
 
 /* Dummy functions used to mark the start/end address of the file. */
 static void StartAddr(void);
@@ -297,7 +296,7 @@ void VQA_StopTimerInt(VQAHandleP *vqap)
 *
 ****************************************************************************/
 
-void far TimerCallback(void)
+void TimerCallback(void)
 {
 	VQATickCount++;
 }
@@ -972,7 +971,7 @@ long CopyAudio(VQAHandleP *vqap)
 *
 ****************************************************************************/
 
-void far cdecl AudioCallback(WORD wDriverHandle,WORD wAction,WORD wSampleID)
+void cdecl AudioCallback(WORD wDriverHandle,WORD wAction,WORD wSampleID)
 {
 	VQAAudio  *audio;
 	VQAConfig *config;

--- a/VQ/LVGL/CAPTION.c
+++ b/VQ/LVGL/CAPTION.c
@@ -40,7 +40,7 @@
 ****************************************************************************/
 
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "../VQM32/font.h"
 #include "../VQM32/text.h"
 #include "../VQM32/graphics.h"

--- a/VQ/LVGL/DRAWER.c
+++ b/VQ/LVGL/DRAWER.c
@@ -72,7 +72,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <stdio.h>
 #include <string.h>
 #include "vq.h"

--- a/VQ/LVGL/INCLUDE/sos.h
+++ b/VQ/LVGL/INCLUDE/sos.h
@@ -36,7 +36,16 @@
 #define  _SOS_DEFINED   
 #include "sosdefs.h"
 
+#ifndef far
+#define far
+#endif
+#ifndef interrupt
+#define interrupt
+#endif
+
+#ifdef __WATCOMC__
 #pragma pack(4)
+#endif
  
 // error definition for sound operating system  
 #define  _SOS_ERR          -1
@@ -531,11 +540,13 @@ enum
 // define for special 18.2 callback rate to dos
 #define  _TIMER_DOS_RATE   0xff00
 
+#ifdef __WATCOMC__
 #pragma pack()
 
 #pragma aux int_3 = "int 3"
- 
-#pragma pack( 1 ) 
+
+#pragma pack( 1 )
+#endif
 typedef struct
 {
 	unsigned       region_size;
@@ -557,7 +568,9 @@ typedef struct
 
 } VDS_STRUCT;
 
-#pragma pack() 
+#ifdef __WATCOMC__
+#pragma pack()
+#endif
 
 #include "sosdata.h"
 #include "sosfnct.h"

--- a/VQ/LVGL/INCLUDE/sosdata.h
+++ b/VQ/LVGL/INCLUDE/sosdata.h
@@ -37,7 +37,16 @@
 
 #include <stddef.h>
 
-#pragma pack(4) 
+#ifndef far
+#define far
+#endif
+#ifndef interrupt
+#define interrupt
+#endif
+
+#ifdef __WATCOMC__
+#pragma pack(4)
+#endif
 extern   WORD     _sosDIGIData_Start;
 extern   WORD     _sosDIGIData_End;
 extern   WORD     _wSOSDriverLinear[];
@@ -122,7 +131,9 @@ extern   WORD  wDetectParam;
 }
 #endif 
 
+#ifdef __WATCOMC__
 #pragma pack()
+#endif
 
 #endif
 

--- a/VQ/LVGL/LOADER.c
+++ b/VQ/LVGL/LOADER.c
@@ -70,7 +70,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <stddef.h>
 #include "vq.h"

--- a/VQ/LVGL/TASK.c
+++ b/VQ/LVGL/TASK.c
@@ -58,7 +58,7 @@
 ****************************************************************************/
 
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 
 #include <string.h>
 #include <conio.h>


### PR DESCRIPTION
## Summary
- clean up LVGL VQA sources for modern compilers
- replace `<malloc.h>` with `<stdlib.h>`
- drop old `far` qualifiers and guard Watcom pragmas

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: ISO C++ forbids… and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853cfb21e3c8325b2d70662ac29fa04