### PR TITLE
Add LVGL input bridge

### DIFF
--- a/CODE/CMakeLists.txt
+++ b/CODE/CMakeLists.txt
@@ -281,6 +281,7 @@ _WSPROTO.CPP
 lvgl/lvgl_bridge.c
 lvgl/lvgl_backend.c
 lvgl/terminal.c
+lvgl/lvgl_input.c
 )
 
 set(CODE_ASM

--- a/CODE/KEY.CPP
+++ b/CODE/KEY.CPP
@@ -57,6 +57,9 @@
 #include "key.h"
 
 #include	"monoc.h"
+#ifdef USE_LVGL
+#include "lvgl/lvgl_input.h"
+#endif
 
 //void Message_Loop(void);
 
@@ -231,15 +234,18 @@ bool WWKeyboardClass::Put_Key_Message(unsigned short vk_key, bool release)
 		}
 	}
 
-	if (release) {
-		vk_key |= WWKEY_RLS_BIT;
-	}
+        if (release) {
+                vk_key |= WWKEY_RLS_BIT;
+        }
 
-	/*
-	** Finally use the put command to enter the key into the keyboard
-	** system.
-	*/
-	return(Put(vk_key));
+        /*
+        ** Finally use the put command to enter the key into the keyboard
+        ** system.
+        */
+#ifdef USE_LVGL
+        lvgl_input_push_key(vk_key & 0xFF, !release);
+#endif
+        return(Put(vk_key));
 }
 
 
@@ -265,13 +271,17 @@ bool WWKeyboardClass::Put_Key_Message(unsigned short vk_key, bool release)
  *=============================================================================================*/
 bool WWKeyboardClass::Put_Mouse_Message(unsigned short vk_key, int x, int y, bool release)
 {
-	if (Available_Buffer_Room() >= 3 && Is_Mouse_Key(vk_key)) {
-		Put_Key_Message(vk_key, release);
-		Put((unsigned short)x);
-		Put((unsigned short)y);
-		return(true);
-	}
-	return(false);
+        if (Available_Buffer_Room() >= 3 && Is_Mouse_Key(vk_key)) {
+                Put_Key_Message(vk_key, release);
+                Put((unsigned short)x);
+                Put((unsigned short)y);
+#ifdef USE_LVGL
+                lvgl_input_set_mouse_pos(x, y);
+                lvgl_input_push_mouse_button(vk_key & 0xFF, !release);
+#endif
+                return(true);
+        }
+        return(false);
 }
 
 

--- a/CODE/KEYBOARD.CPP
+++ b/CODE/KEYBOARD.CPP
@@ -45,6 +45,9 @@
 #include "keyboard.h"
 
 #include	"monoc.h"
+#ifdef USE_LVGL
+#include "lvgl/lvgl_input.h"
+#endif
 
 //void Message_Loop(void);
 
@@ -208,15 +211,18 @@ bool WWKeyboardClass::Put_Key_Message(unsigned short vk_key, bool release)
 		}
 	}
 
-	if (release) {
-		vk_key |= WWKEY_RLS_BIT;
-	}
+        if (release) {
+                vk_key |= WWKEY_RLS_BIT;
+        }
 
-	//
-	// Finally use the put command to enter the key into the keyboard
-	// system.
-	//
-	return(Put(vk_key));
+        //
+        // Finally use the put command to enter the key into the keyboard
+        // system.
+        //
+#ifdef USE_LVGL
+        lvgl_input_push_key(vk_key & 0xFF, !release);
+#endif
+        return(Put(vk_key));
 
 
 
@@ -398,17 +404,25 @@ void WWKeyboardClass::Message_Handler(HWND , UINT message, UINT wParam, LONG lPa
 			Put_Key_Message((unsigned short)wParam, true);
 			break;
 
-		case WM_LBUTTONDOWN:
-			Put_Key_Message(VK_LBUTTON);
-			Put(LOWORD(lParam));
-			Put(HIWORD(lParam));
-			break;
+                case WM_LBUTTONDOWN:
+                        Put_Key_Message(VK_LBUTTON);
+                        Put(LOWORD(lParam));
+                        Put(HIWORD(lParam));
+#ifdef USE_LVGL
+                        lvgl_input_set_mouse_pos(LOWORD(lParam), HIWORD(lParam));
+                        lvgl_input_push_mouse_button(VK_LBUTTON, 1);
+#endif
+                        break;
 
-		case WM_LBUTTONUP:
-			Put_Key_Message(VK_LBUTTON, true);
-			Put(LOWORD(lParam));
-			Put(HIWORD(lParam));
-			break;
+                case WM_LBUTTONUP:
+                        Put_Key_Message(VK_LBUTTON, true);
+                        Put(LOWORD(lParam));
+                        Put(HIWORD(lParam));
+#ifdef USE_LVGL
+                        lvgl_input_set_mouse_pos(LOWORD(lParam), HIWORD(lParam));
+                        lvgl_input_push_mouse_button(VK_LBUTTON, 0);
+#endif
+                        break;
 
 		case WM_LBUTTONDBLCLK:
 			Put_Key_Message(VK_LBUTTON, true);
@@ -419,17 +433,25 @@ void WWKeyboardClass::Message_Handler(HWND , UINT message, UINT wParam, LONG lPa
 			Put(HIWORD(lParam));
 			break;
 
-		case WM_MBUTTONDOWN:
-			Put_Key_Message(VK_MBUTTON);
-			Put(LOWORD(lParam));
-			Put(HIWORD(lParam));
-			break;
+                case WM_MBUTTONDOWN:
+                        Put_Key_Message(VK_MBUTTON);
+                        Put(LOWORD(lParam));
+                        Put(HIWORD(lParam));
+#ifdef USE_LVGL
+                        lvgl_input_set_mouse_pos(LOWORD(lParam), HIWORD(lParam));
+                        lvgl_input_push_mouse_button(VK_MBUTTON, 1);
+#endif
+                        break;
 
-		case WM_MBUTTONUP:
-			Put_Key_Message(VK_MBUTTON, true);
-			Put(LOWORD(lParam));
-			Put(HIWORD(lParam));
-			break;
+                case WM_MBUTTONUP:
+                        Put_Key_Message(VK_MBUTTON, true);
+                        Put(LOWORD(lParam));
+                        Put(HIWORD(lParam));
+#ifdef USE_LVGL
+                        lvgl_input_set_mouse_pos(LOWORD(lParam), HIWORD(lParam));
+                        lvgl_input_push_mouse_button(VK_MBUTTON, 0);
+#endif
+                        break;
 
 		case WM_MBUTTONDBLCLK:
 			Put_Key_Message(VK_MBUTTON, true);
@@ -440,17 +462,25 @@ void WWKeyboardClass::Message_Handler(HWND , UINT message, UINT wParam, LONG lPa
 			Put(HIWORD(lParam));
 			break;
 
-		case WM_RBUTTONDOWN:
-			Put_Key_Message(VK_RBUTTON);
-			Put(LOWORD(lParam));
-			Put(HIWORD(lParam));
-			break;
+                case WM_RBUTTONDOWN:
+                        Put_Key_Message(VK_RBUTTON);
+                        Put(LOWORD(lParam));
+                        Put(HIWORD(lParam));
+#ifdef USE_LVGL
+                        lvgl_input_set_mouse_pos(LOWORD(lParam), HIWORD(lParam));
+                        lvgl_input_push_mouse_button(VK_RBUTTON, 1);
+#endif
+                        break;
 
-		case WM_RBUTTONUP:
-			Put_Key_Message(VK_RBUTTON, true);
-			Put(LOWORD(lParam));
-			Put(HIWORD(lParam));
-			break;
+                case WM_RBUTTONUP:
+                        Put_Key_Message(VK_RBUTTON, true);
+                        Put(LOWORD(lParam));
+                        Put(HIWORD(lParam));
+#ifdef USE_LVGL
+                        lvgl_input_set_mouse_pos(LOWORD(lParam), HIWORD(lParam));
+                        lvgl_input_push_mouse_button(VK_RBUTTON, 0);
+#endif
+                        break;
 
 		case WM_RBUTTONDBLCLK:
 			Put_Key_Message(VK_RBUTTON, true);

--- a/CODE/STARTUP.CPP
+++ b/CODE/STARTUP.CPP
@@ -49,6 +49,7 @@
 #ifdef USE_LVGL
 #include "../src/lvgl/src/lvgl.h"
 #include "lvgl/lvgl_backend.h"
+#include "lvgl/lvgl_input.h"
 #endif
 
 #ifdef MCIMPEG // Denzil 6/15/98
@@ -124,6 +125,7 @@ int main(int argc, char * argv[])
     if(lvgl_init_backend(NULL) != 0) {
         return 1;
     }
+    lvgl_input_init();
 #endif
 
 	#ifndef MPEGMOVIE // Denzil 6/10/98

--- a/CODE/lvgl/lvgl_input.c
+++ b/CODE/lvgl/lvgl_input.c
@@ -1,0 +1,90 @@
+#include "lvgl_input.h"
+#include "../../src/lvgl/src/lvgl.h"
+#include "../../src/debug_log.h"
+
+#define KEY_QUEUE_LEN 32
+
+struct key_event {
+    uint32_t key;
+    lv_indev_state_t state;
+};
+
+static struct key_event key_queue[KEY_QUEUE_LEN];
+static int key_head;
+static int key_tail;
+
+static int16_t mouse_x;
+static int16_t mouse_y;
+static lv_indev_state_t mouse_state;
+
+static lv_indev_t *key_indev;
+static lv_indev_t *mouse_indev;
+
+static void keyboard_read(lv_indev_t *indev, lv_indev_data_t *data)
+{
+    (void)indev;
+    if(key_head != key_tail) {
+        *data = (lv_indev_data_t){0};
+        data->state = key_queue[key_head].state;
+        data->key = key_queue[key_head].key;
+        key_head = (key_head + 1) % KEY_QUEUE_LEN;
+    } else {
+        data->state = LV_INDEV_STATE_RELEASED;
+        data->key = 0;
+    }
+}
+
+static void mouse_read(lv_indev_t *indev, lv_indev_data_t *data)
+{
+    (void)indev;
+    data->point.x = mouse_x;
+    data->point.y = mouse_y;
+    data->state = mouse_state;
+}
+
+void lvgl_input_init(void)
+{
+    LOG_CALL("lvgl_input_init\n");
+    key_head = key_tail = 0;
+    mouse_x = mouse_y = 0;
+    mouse_state = LV_INDEV_STATE_RELEASED;
+
+    key_indev = lv_indev_create();
+    if(key_indev) {
+        lv_indev_set_type(key_indev, LV_INDEV_TYPE_KEYPAD);
+        lv_indev_set_read_cb(key_indev, keyboard_read);
+        lv_indev_set_mode(key_indev, LV_INDEV_MODE_EVENT);
+    }
+
+    mouse_indev = lv_indev_create();
+    if(mouse_indev) {
+        lv_indev_set_type(mouse_indev, LV_INDEV_TYPE_POINTER);
+        lv_indev_set_read_cb(mouse_indev, mouse_read);
+        lv_indev_set_mode(mouse_indev, LV_INDEV_MODE_EVENT);
+    }
+}
+
+void lvgl_input_push_key(unsigned int key, int pressed)
+{
+    int next = (key_tail + 1) % KEY_QUEUE_LEN;
+    if(next == key_head) {
+        return; /* drop */
+    }
+    key_queue[key_tail].key = key;
+    key_queue[key_tail].state = pressed ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
+    key_tail = next;
+}
+
+void lvgl_input_set_mouse_pos(int x, int y)
+{
+    mouse_x = (int16_t)x;
+    mouse_y = (int16_t)y;
+}
+
+void lvgl_input_push_mouse_button(unsigned int button, int pressed)
+{
+    (void)button; /* only left button used */
+    mouse_state = pressed ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
+}
+
+

--- a/CODE/lvgl/lvgl_input.h
+++ b/CODE/lvgl/lvgl_input.h
@@ -1,0 +1,17 @@
+#ifndef LVGL_INPUT_H
+#define LVGL_INPUT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void lvgl_input_init(void);
+void lvgl_input_push_key(unsigned int key, int pressed);
+void lvgl_input_set_mouse_pos(int x, int y);
+void lvgl_input_push_mouse_button(unsigned int button, int pressed);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LVGL_INPUT_H */

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -160,3 +160,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
   next frame while displaying the current one.
 - Registered a custom LVGL image decoder so predecoded VQ frames use
   `LV_COLOR_FORMAT_RAW` for display.
+- Added LVGL input bridge that maps keyboard and mouse events to lv_indev callbacks.


### PR DESCRIPTION
## Summary
- implement `lvgl_input` module for LVGL input devices
- forward keyboard and mouse events to LVGL from message handlers
- initialize LVGL input devices at startup
- document LVGL input bridge in PROGRESS.md

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: missing headers and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685409a316d88325aa131e065ea19990