### PR TITLE
Introduce portable file I/O layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
     src/ddraw/ddraw_stub.c
     src/fast_stub.c
     src/ipx_stub.c
+    src/file_io.c
 )
 if(DEFINED PLATFORM_EXCLUDE_SOURCES)
     list(REMOVE_ITEM SOURCES ${PLATFORM_EXCLUDE_SOURCES})

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -161,3 +161,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Registered a custom LVGL image decoder so predecoded VQ frames use
   `LV_COLOR_FORMAT_RAW` for display.
 - Added LVGL input bridge that maps keyboard and mouse events to lv_indev callbacks.
+- Introduced portable file I/O wrappers (`src/file_io.c`) that replace DOS-specific calls with standard POSIX functions.

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include "_file.h"
+
+WORD ibm_getdisk(void)
+{
+    /* Drive numbers are meaningless on modern systems. */
+    return 0;
+}
+
+WORD ibm_setdisk(WORD drive)
+{
+    (void)drive;
+    return 0;
+}
+
+WORD ibm_close(WORD handle)
+{
+    return close(handle);
+}
+
+WORD ibm_unlink(BYTE const *name)
+{
+    return unlink((const char *)name);
+}
+
+LONG ibm_lseek(WORD handle, LONG offset, WORD where)
+{
+    return lseek(handle, offset, where);
+}
+
+UWORD ibm_read(WORD handle, VOID *ptr, UWORD bytes)
+{
+    return (UWORD)read(handle, ptr, bytes);
+}
+
+UWORD ibm_write(WORD handle, VOID *ptr, UWORD bytes)
+{
+    return (UWORD)write(handle, ptr, bytes);
+}
+
+WORD ibm_open(BYTE const *name, UWORD mode, WORD attrib)
+{
+    (void)attrib;
+    return open((const char *)name, mode, 0666);
+}
+
+WORD ibm_chdir(BYTE const *path)
+{
+    return chdir((const char *)path);
+}
+


### PR DESCRIPTION
## Summary
- add `src/file_io.c` implementing `ibm_*` file helpers using POSIX
- build portable file I/O layer via CMake
- document the change in `PROGRESS.md`

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON`
- `cmake --build build` *(fails: many compile errors)*
- `cmake --build build --target ipx_stub_test` *(fails: unused variable)*
- `ctest --test-dir build` *(fails: test executables missing)*

------
https://chatgpt.com/codex/tasks/task_e_685414c685fc8325b4094f9a6f3e4240