### PR TITLE
Apply pedantic build flags to WWLVGL

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -163,3 +163,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Added LVGL input bridge that maps keyboard and mouse events to lv_indev callbacks.
 - Introduced portable file I/O wrappers (`src/file_io.c`) that replace DOS-specific calls with standard POSIX functions.
 - Started restructuring WWLVGL build using a dedicated CMakeLists with component library enumeration.
+- Enabled pedantic compilation flags in `WWLVGL/CMakeLists.txt` so every file builds with `-std=gnu11 -pedantic -Wall -Wextra -Werror`.

--- a/WWLVGL/CMakeLists.txt
+++ b/WWLVGL/CMakeLists.txt
@@ -55,3 +55,10 @@ target_include_directories(lv_ww_lib PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/../VQ/INCLUDE/WWLIB32
 )
 
+# Enforce strict compilation flags for all sources
+set_target_properties(lv_ww_lib PROPERTIES
+    C_STANDARD 11
+    C_EXTENSIONS ON
+)
+target_compile_options(lv_ww_lib PRIVATE -std=gnu11 -pedantic -Wall -Wextra -Werror)
+

--- a/WWLVGL/PROGRESS.md
+++ b/WWLVGL/PROGRESS.md
@@ -23,6 +23,4 @@ Each of these will need a modern replacement or a temporary stub in order to bui
 
 As the port progresses, updates on how each dependency has been replaced or stubbed should be recorded here.
 
--
--
--
+- Enabled strict build flags in `CMakeLists.txt` so all WWLVGL sources compile with `-std=gnu11 -pedantic -Wall -Wextra -Werror`.


### PR DESCRIPTION
## Summary
- tighten WWLVGL build checks with `-std=gnu11 -pedantic -Wall -Wextra -Werror`
- document the change in both progress logs

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: new.h missing and pedantic errors)*

------
https://chatgpt.com/codex/tasks/task_e_68542ae1407083258db75dbd7c396391