### PR TITLE
Refactor MEM headers for C11

### DIFF
--- a/WWLVGL/INCLUDE/keyboard.h
+++ b/WWLVGL/INCLUDE/keyboard.h
@@ -35,7 +35,7 @@
 #ifndef KEYBOARD_H
 #define KEYBOARD_H
  
-#include <WWSTD.H>
+#include "wwstd.h"
 
 typedef enum {
 	WWKEY_SHIFT_BIT	= 0x100,

--- a/WWLVGL/INCLUDE/memflag.h
+++ b/WWLVGL/INCLUDE/memflag.h
@@ -1,113 +1,68 @@
 /*
-**	Command & Conquer Red Alert(tm)
-**	Copyright 2025 Electronic Arts Inc.
-**
-**	This program is free software: you can redistribute it and/or modify
-**	it under the terms of the GNU General Public License as published by
-**	the Free Software Foundation, either version 3 of the License, or
-**	(at your option) any later version.
-**
-**	This program is distributed in the hope that it will be useful,
-**	but WITHOUT ANY WARRANTY; without even the implied warranty of
-**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**	GNU General Public License for more details.
-**
-**	You should have received a copy of the GNU General Public License
-**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Command & Conquer Red Alert(tm)
+ * Copyright 2025 Electronic Arts Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
-/***************************************************************************
- **     C O N F I D E N T I A L --- W E S T W O O D   S T U D I O S       **
- ***************************************************************************
- *                                                                         *
- *                 Project Name : Memory System                            *
- *                                                                         *
- *                    File Name : MEMFLAG.H                                *
- *                                                                         *
- *                   Programmer : Jeff Wilson                              *
- *                                                                         *
- *                   Start Date : April 4, 1994                            *
- *                                                                         *
- *                  Last Update : September 8, 1994   [IML]                *
- *                                                                         *
- *-------------------------------------------------------------------------*
- * Functions:                                                              *
- * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+/****************************************************************************
+ * C O N F I D E N T I A L --- W E S T W O O D   S T U D I O S
+ ****************************************************************************
+ * Project Name : Memory System
+ * File Name    : MEMFLAG.H
+ * Programmer   : Jeff Wilson
+ * Start Date   : April 4, 1994
+ * Last Update  : June 19, 2025
+ ****************************************************************************/
 #ifndef MEMFLAG_H
 #define MEMFLAG_H
-// Memory Flags
-/*
-**	Memory allocation flags.  These are the flags that are passed into Alloc
-**	in order to control the type of memory allocated.
-*/
+
+#include <stddef.h>
+
+/* Memory allocation flags used by Alloc */
 typedef enum {
-	MEM_NORMAL = 0x0000,		// Default memory (normal).
-	MEM_NEW	  = 0x0001,		// Called by the operator new and was overloaded.
-	MEM_CLEAR  = 0x0002,		// Clear memory before returning.
-	MEM_REAL   = 0x0004,		// Clear memory before returning.
-	MEM_TEMP   = 0x0008,		// Clear memory before returning.
-	MEM_LOCK   = 0x0010,		// Lock the memory that we allocated
+    MEM_NORMAL = 0x0000,
+    MEM_CLEAR  = 0x0002,
+    MEM_REAL   = 0x0004,
+    MEM_TEMP   = 0x0008,
+    MEM_LOCK   = 0x0010
 } MemoryFlagType;
 
+/* Prototypes for VMPAGEIN.ASM */
+void Force_VM_Page_In(void *buffer, int length);
 
-/*
-** Prototypes for VMPAGEIN.ASM
-*/
-extern "C"{
-	void __cdecl Force_VM_Page_In (void *buffer, int length);
-}
+/* Prototypes for ALLOC.C */
+void *Alloc(unsigned long bytes_to_alloc, MemoryFlagType flags);
+void Free(const void *pointer);
+void DPMI_Lock(const void *ptr, long size);
+void DPMI_Unlock(const void *ptr, long size);
+void *Resize_Alloc(void *original_ptr, unsigned long new_size_in_bytes);
+long Ram_Free(MemoryFlagType flag);
+long Heap_Size(MemoryFlagType flag);
+long Total_Ram_Free(MemoryFlagType flag);
 
-/*=========================================================================*/
-/* The following prototypes are for the file: ALLOC.CPP							*/
-/*=========================================================================*/
+/* Prototypes for MEM_COPY.ASM */
+void Mem_Copy(const void *source, void *dest, unsigned long bytes_to_copy);
 
-void * operator new(size_t size, MemoryFlagType flag);
-void * operator new[] (size_t size, MemoryFlagType flag);
-void	*Alloc(unsigned long bytes_to_alloc, MemoryFlagType flags);
-void	Free(void const *pointer);
-void	DPMI_Lock(VOID const *ptr, long const size);
-void	DPMI_Unlock(void const *ptr, long const size);
-void	*Resize_Alloc(void *original_ptr, unsigned long new_size_in_bytes);
-long	Ram_Free(MemoryFlagType flag);
-long	Heap_Size(MemoryFlagType flag);
-long	Total_Ram_Free(MemoryFlagType flag);
-
-#ifdef __WATCOMC__
-#pragma option -Jgd
-#endif
-
-inline void * operator new(size_t size, MemoryFlagType flag)
+static inline void *Add_Long_To_Pointer(const void *ptr, long size)
 {
-	return(Alloc(size, flag));
-}
-inline void * operator new[] (size_t size, MemoryFlagType flag)
-{
-	return(Alloc(size, flag));
-}
-
-#ifdef __WATCOMC__
-#pragma option -Jgd
-#endif
-
-/*=========================================================================*/
-/* The following prototypes are for the file: MEM_COPY.ASM						*/
-/*=========================================================================*/
-
-extern "C" {
-	void __cdecl Mem_Copy(void const *source, void *dest, unsigned long bytes_to_copy);
-}
-
-
-inline void *Add_Long_To_Pointer(void const *ptr, long size)
-{
- 	return ((void *) ( (char const *) ptr + size));
+    return (void *)((const char *)ptr + size);
 }
 
 extern void (*Memory_Error)(void);
 extern void (*Memory_Error_Exit)(char *string);
+extern unsigned long MinRam;
+extern unsigned long MaxRam;
 
-extern unsigned long MinRam;		// Record of least memory at worst case.
-extern unsigned long MaxRam;		// Record of total allocated at worst case.
-
-
-#endif
+#endif /* MEMFLAG_H */

--- a/WWLVGL/PROGRESS.md
+++ b/WWLVGL/PROGRESS.md
@@ -26,3 +26,4 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Enabled strict build flags in `CMakeLists.txt` so all WWLVGL sources compile with `-std=gnu11 -pedantic -Wall -Wextra -Werror`.
 - Switched audio playback to the bundled miniaudio library.
 - Began C11 cleanup of MEM module: removed DOS-only headers, added stub `timer.h`, and replaced deprecated includes.
+- Replaced legacy MEMFLAG.H with C11 version and added timer stubs for MEM build.

--- a/WWLVGL/SRCDEBUG/ALLOC.c
+++ b/WWLVGL/SRCDEBUG/ALLOC.c
@@ -74,7 +74,7 @@ static unsigned long TotalRam = 0L;
 static unsigned long Memory_Calls = 0L;
 
 void (*Memory_Error)(void) = NULL;
-extern void (*Memory_Error_Exit)(char *string)=NULL;
+void (*Memory_Error_Exit)(char *string) = NULL;
 
 
 //#define MEM_CHECK
@@ -94,9 +94,11 @@ extern void (*Memory_Error_Exit)(char *string)=NULL;
  * HISTORY:                                                                *
  *   06/23/1995 PWG : Created.                                             *
  *=========================================================================*/
-#include"mono.h"
-void DPMI_Lock(VOID const *, long const )
+#include "mono.h"
+void DPMI_Lock(const void *ptr, long size)
 {
+    (void)ptr;
+    (void)size;
 }
 
 /***************************************************************************
@@ -111,8 +113,10 @@ void DPMI_Lock(VOID const *, long const )
  * HISTORY:                                                                *
  *   06/23/1995 PWG : Created.                                             *
  *=========================================================================*/
-void DPMI_Unlock(void const *, long const )
+void DPMI_Unlock(const void *ptr, long size)
 {
+    (void)ptr;
+    (void)size;
 }
 
 /***************************************************************************


### PR DESCRIPTION
## Summary
- modernize `memflag.h` with C11 style comments and portable function prototypes
- update `keyboard.h` include to use lowercase `wwstd.h`
- stub timer usage in `mem.c` and use `clock()` as a source of ticks
- fix extern definitions in `ALLOC.c`
- note work in `PROGRESS.md`

## Testing
- `cmake --build WWLVGL/build -- -j$(nproc)` *(fails: unknown type name 'class')*

------
https://chatgpt.com/codex/tasks/task_e_6854582e32188325b35006c5211eabb3