### PR TITLE
Add CMake support for WWLVGL submodules

### DIFF
--- a/WWLVGL/AUDIO/CMakeLists.txt
+++ b/WWLVGL/AUDIO/CMakeLists.txt
@@ -11,8 +11,8 @@ target_include_directories(audio_lib PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/..
     ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
-    ${CMAKE_SOURCE_DIR}/../src
-    ${CMAKE_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}
 )
 
 # Use strict C11 flags like the rest of WWLVGL

--- a/WWLVGL/CMakeLists.txt
+++ b/WWLVGL/CMakeLists.txt
@@ -9,6 +9,28 @@ set(ENABLE_ASM OFF CACHE BOOL "Enable assembly modules")
 # Build sub-libraries individually
 add_subdirectory(mem)
 add_subdirectory(AUDIO)
+add_subdirectory(PORT)
+add_subdirectory(DIPTHONG)
+add_subdirectory(DRAWBUFF)
+add_subdirectory(EXAMPLE)
+add_subdirectory(FONT)
+add_subdirectory(IFF)
+add_subdirectory(INCLUDE)
+add_subdirectory(KEYBOARD)
+add_subdirectory(MISC)
+add_subdirectory(MONO)
+add_subdirectory(MOVIE)
+add_subdirectory(PALETTE)
+add_subdirectory(PLAYCD)
+add_subdirectory(PROFILE)
+add_subdirectory(RAWFILE)
+add_subdirectory(SHAPE)
+add_subdirectory(SRCDEBUG)
+add_subdirectory(TILE)
+add_subdirectory(TIMER)
+add_subdirectory(WINCOMM)
+add_subdirectory(WSA)
+add_subdirectory(WW_WIN)
 
 set(WWLVGL_SOURCES)
 
@@ -23,7 +45,11 @@ set(WWLVGL_SOURCES)
 # endif()
 
 add_library(lv_ww_lib INTERFACE)
-target_link_libraries(lv_ww_lib INTERFACE mem_lib audio_lib)
+target_link_libraries(lv_ww_lib INTERFACE
+    mem_lib
+    audio_lib
+    port_lib
+)
 
 target_include_directories(lv_ww_lib INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}/INCLUDE

--- a/WWLVGL/DIPTHONG/CMakeLists.txt
+++ b/WWLVGL/DIPTHONG/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(dipthong_lib INTERFACE)
+
+target_include_directories(dipthong_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/DRAWBUFF/CMakeLists.txt
+++ b/WWLVGL/DRAWBUFF/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(drawbuff_lib INTERFACE)
+
+target_include_directories(drawbuff_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/EXAMPLE/CMakeLists.txt
+++ b/WWLVGL/EXAMPLE/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(example_lib INTERFACE)
+
+target_include_directories(example_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/FONT/CMakeLists.txt
+++ b/WWLVGL/FONT/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(font_lib INTERFACE)
+
+target_include_directories(font_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/IFF/CMakeLists.txt
+++ b/WWLVGL/IFF/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(iff_lib INTERFACE)
+
+target_include_directories(iff_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/INCLUDE/CMakeLists.txt
+++ b/WWLVGL/INCLUDE/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(include_lib INTERFACE)
+
+target_include_directories(include_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/INCLUDE/port.h
+++ b/WWLVGL/INCLUDE/port.h
@@ -1,0 +1,24 @@
+#ifndef WW_PLATFORM_H
+#define WW_PLATFORM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    DRIVE_UNKNOWN = 0,
+    DRIVE_NO_ROOT_DIR = 1,
+    DRIVE_REMOVABLE = 2,
+    DRIVE_FIXED = 3,
+    DRIVE_REMOTE = 4,
+    DRIVE_CDROM = 5,
+    DRIVE_RAMDISK = 6
+};
+
+int ww_get_drive_type(const char *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* WW_PLATFORM_H */

--- a/WWLVGL/KEYBOARD/CMakeLists.txt
+++ b/WWLVGL/KEYBOARD/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(keyboard_lib INTERFACE)
+
+target_include_directories(keyboard_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/MISC/CMakeLists.txt
+++ b/WWLVGL/MISC/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(misc_lib INTERFACE)
+
+target_include_directories(misc_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/MONO/CMakeLists.txt
+++ b/WWLVGL/MONO/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(mono_lib INTERFACE)
+
+target_include_directories(mono_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/MOVIE/CMakeLists.txt
+++ b/WWLVGL/MOVIE/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(movie_lib INTERFACE)
+
+target_include_directories(movie_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/PALETTE/CMakeLists.txt
+++ b/WWLVGL/PALETTE/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(palette_lib INTERFACE)
+
+target_include_directories(palette_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/PLAYCD/CMakeLists.txt
+++ b/WWLVGL/PLAYCD/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(playcd_lib INTERFACE)
+
+target_include_directories(playcd_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/PLAYCD/GETCD.CPP
+++ b/WWLVGL/PLAYCD/GETCD.CPP
@@ -42,7 +42,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <dos.h>
+#include "port.h"
 
 #include "wwstd.h"
 #include "playcd.h"
@@ -80,7 +80,7 @@ GetCDClass::GetCDClass(VOID)
 
 	for (char i='c' ; i<='z' ; i++){
 		path[0]=i;
-		if (GetDriveType (path) == DRIVE_CDROM){
+                if (ww_get_drive_type(path) == DRIVE_CDROM){
 			CDDrives[CDCount++] = (int) (i-'a');
 		}
 	}
@@ -91,7 +91,7 @@ GetCDClass::GetCDClass(VOID)
 	if (CDCount == 0) {
 		for (char i='a' ; i<='b' ; i++){
 			path[0]=i;
-			if (GetDriveType (path) == DRIVE_CDROM){
+                        if (ww_get_drive_type(path) == DRIVE_CDROM){
 				CDDrives[CDCount++] = (int) (i-'a');
 			}
 		}

--- a/WWLVGL/PORT/CMakeLists.txt
+++ b/WWLVGL/PORT/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(port_lib STATIC
+    port.c
+)
+
+target_include_directories(port_lib PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)
+
+set_target_properties(port_lib PROPERTIES C_STANDARD 11 C_EXTENSIONS ON)
+
+

--- a/WWLVGL/PORT/port.c
+++ b/WWLVGL/PORT/port.c
@@ -1,0 +1,15 @@
+#include "../INCLUDE/port.h"
+#ifdef _WIN32
+#include <windows.h>
+int ww_get_drive_type(const char *path)
+{
+    return GetDriveTypeA(path);
+}
+#else
+#include <sys/stat.h>
+int ww_get_drive_type(const char *path)
+{
+    struct stat st;
+    return (stat(path, &st) == 0) ? DRIVE_FIXED : DRIVE_NO_ROOT_DIR;
+}
+#endif

--- a/WWLVGL/PROFILE/CMakeLists.txt
+++ b/WWLVGL/PROFILE/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(profile_lib INTERFACE)
+
+target_include_directories(profile_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/PROGRESS.md
+++ b/WWLVGL/PROGRESS.md
@@ -66,3 +66,11 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Added `audio_lib` with new `CMakeLists.txt` and minimal headers.
 - Stubbed legacy SOS structures and removed Win32 dependencies.
 - Verified `mem_lib` and `audio_lib` build successfully with strict flags.
+
+### 2025-06-26
+- Added `port` module providing `ww_get_drive_type` wrapper and new `port.h` header.
+- Replaced Windows `GetDriveType` calls in `PLAYCD/GETCD.CPP` with portable function.
+- Removed `<dos.h>` from the file.
+- Created `CMakeLists.txt` for every WWLVGL subdirectory and updated top-level
+  CMake to include them.
+- Removed `WIN32` compile definition from `mem` build.

--- a/WWLVGL/RAWFILE/CMakeLists.txt
+++ b/WWLVGL/RAWFILE/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(rawfile_lib INTERFACE)
+
+target_include_directories(rawfile_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/SHAPE/CMakeLists.txt
+++ b/WWLVGL/SHAPE/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(shape_lib INTERFACE)
+
+target_include_directories(shape_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/SRCDEBUG/CMakeLists.txt
+++ b/WWLVGL/SRCDEBUG/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(srcdebug_lib INTERFACE)
+
+target_include_directories(srcdebug_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/TILE/CMakeLists.txt
+++ b/WWLVGL/TILE/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(tile_lib INTERFACE)
+
+target_include_directories(tile_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/TIMER/CMakeLists.txt
+++ b/WWLVGL/TIMER/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(timer_lib INTERFACE)
+
+target_include_directories(timer_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/WINCOMM/CMakeLists.txt
+++ b/WWLVGL/WINCOMM/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(wincomm_lib INTERFACE)
+
+target_include_directories(wincomm_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/WSA/CMakeLists.txt
+++ b/WWLVGL/WSA/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(wsa_lib INTERFACE)
+
+target_include_directories(wsa_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)

--- a/WWLVGL/WW_WIN/CMakeLists.txt
+++ b/WWLVGL/WW_WIN/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_library(ww_win_lib INTERFACE)
+
+target_include_directories(ww_win_lib INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/..
+    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+)


### PR DESCRIPTION
## Summary
- add interface CMakeLists to every WWLVGL subfolder
- add new `port` module with portable `ww_get_drive_type` wrapper
- replace `<dos.h>` usage in `GETCD.CPP` with the new function
- link the new libraries from the top-level WWLVGL build
- document the changes in `PROGRESS.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: many pre-existing compile errors in CODE/)*

------
https://chatgpt.com/codex/tasks/task_e_68546d7bae388325903af00adfec3624