### PR TITLE
Add portable helpers and cleanup WWLVGL

### DIFF
--- a/WWLVGL/AGENTS.md
+++ b/WWLVGL/AGENTS.md
@@ -17,6 +17,12 @@ These instructions apply to all files within this folder only.
 - After each modification, run available build or test scripts where possible.
 
 Use this file as a quick reference when planning code conversions or dependency replacements within this folder.
+## Coding Guidelines
+
+- Prefer forward slashes in `#include` directives (`<sys/types.h>` rather than `<sys\types.h>`).
+- Avoid `<dos.h>`, `<conio.h>`, and direct Win32 headers except in isolated portability stubs.
+- Replace Win32 functions such as `Sleep` or `GetTickCount` with the wrappers in `PORT/port.c` (`ww_sleep`, `ww_get_ticks`).
+- Stick to the C11 standard library: `<stdint.h>`, `<stdbool.h>`, `<time.h>` and similar headers.
 
 ## Iterative Development
 

--- a/WWLVGL/INCLUDE/port.h
+++ b/WWLVGL/INCLUDE/port.h
@@ -17,6 +17,12 @@ enum {
 
 int ww_get_drive_type(const char *path);
 
+/* Portable replacement for Win32 Sleep */
+void ww_sleep(unsigned int ms);
+
+/* Millisecond tick counter */
+unsigned long ww_get_ticks(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/WWLVGL/PORT/port.c
+++ b/WWLVGL/PORT/port.c
@@ -1,15 +1,39 @@
 #include "../INCLUDE/port.h"
+
 #ifdef _WIN32
 #include <windows.h>
-int ww_get_drive_type(const char *path)
-{
-    return GetDriveTypeA(path);
-}
 #else
 #include <sys/stat.h>
+#include <time.h>
+#endif
+
 int ww_get_drive_type(const char *path)
 {
+#ifdef _WIN32
+    return GetDriveTypeA(path);
+#else
     struct stat st;
     return (stat(path, &st) == 0) ? DRIVE_FIXED : DRIVE_NO_ROOT_DIR;
-}
 #endif
+}
+
+void ww_sleep(unsigned int ms)
+{
+#ifdef _WIN32
+    Sleep(ms);
+#else
+    clock_t start = clock();
+    while (((clock() - start) * 1000 / CLOCKS_PER_SEC) < (clock_t)ms) {
+        /* busy wait */
+    }
+#endif
+}
+
+unsigned long ww_get_ticks(void)
+{
+#ifdef _WIN32
+    return GetTickCount();
+#else
+    return (unsigned long)(clock() * 1000 / CLOCKS_PER_SEC);
+#endif
+}

--- a/WWLVGL/PROFILE/UTIL/PROFILE.CPP
+++ b/WWLVGL/PROFILE/UTIL/PROFILE.CPP
@@ -45,12 +45,11 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <sys\types.h>
-#include <sys\stat.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <fcntl.h>
-#include <malloc.h>
-#include <io.h>
-#include <conio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 #define NAME_TABLE_SIZE 1000000					//Storage space for function names
 #define SAMPLE_START 1								//Offset (in dwords) of sample data in sample file
@@ -117,15 +116,15 @@ int main(int argc, char *argv[])
 	** If the arguments dont make sense then print the usage
 	*/
 	if (argc!=3 ||
-			!strcmpi(argv[1],"/?") ||
-			!strcmpi(argv[1],"/h") ||
-			!strcmpi(argv[1],"/help") ||
-			!strcmpi(argv[1],"-?") ||
-			!strcmpi(argv[1],"-h") ||
-			!strcmpi(argv[1],"-help") ||
-			!strcmpi(argv[1],"?") ||
-			!strcmpi(argv[1],"h") ||
-			!strcmpi(argv[1],"help")){
+			!strcasecmp(argv[1],"/?") ||
+			!strcasecmp(argv[1],"/h") ||
+			!strcasecmp(argv[1],"/help") ||
+			!strcasecmp(argv[1],"-?") ||
+			!strcasecmp(argv[1],"-h") ||
+			!strcasecmp(argv[1],"-help") ||
+			!strcasecmp(argv[1],"?") ||
+			!strcasecmp(argv[1],"h") ||
+			!strcasecmp(argv[1],"help")){
 		Print_Usage();
 		return(0);
 	}
@@ -159,30 +158,30 @@ int main(int argc, char *argv[])
 	/*
 	** Get the function names from the map file
 	*/
-	cprintf ("Extracting function data from map file.\n");
+	printf ("Extracting function data from map file.\n");
 	if (!Extract_Function_Addresses()){
-		cprintf ("Error parsing .MAP file - aborting\n\n");
+		printf ("Error parsing .MAP file - aborting\n\n");
 		return (0);
 	}
 
 	/*
 	** Sort the functions into address order to make it easier to map the functions
 	*/
-	cprintf ("Sorting function list by address");
+	printf ("Sorting function list by address");
 	Sort_Functions();
 
 	/*
 	** Map the addresses in the sample file to the function addresses
 	*/
-	cprintf ("\nMapping profiler hits to functions");
+	printf ("\nMapping profiler hits to functions");
 	Map_Profiler_Hits();
 
 	/*
 	** Sort the functions into order of usage for output
 	*/
-	cprintf ("\nSorting function list by activity");
+	printf ("\nSorting function list by activity");
 	Sort_Functions_Again();
-	cprintf ("\n\n");
+	printf ("\n\n");
 
 	/*
 	** Print the function usage statistics
@@ -213,9 +212,9 @@ int main(int argc, char *argv[])
 
 void Print_My_Name(void)
 {
-	cprintf("Westwood profile data analyzer.\n");
-	cprintf("V 1.0 - 11/17/95\n");
-	cprintf("Programmer - Steve Tall.\n\n");
+	printf("Westwood profile data analyzer.\n");
+	printf("V 1.0 - 11/17/95\n");
+	printf("Programmer - Steve Tall.\n\n");
 }
 
 /***********************************************************************************************
@@ -234,7 +233,7 @@ void Print_My_Name(void)
 
 void Print_Usage (void)
 {
-	cprintf("Usage: PROFILE <sample_file> <map_file)\n\n");
+	printf("Usage: PROFILE <sample_file> <map_file)\n\n");
 }
 
 /***********************************************************************************************
@@ -253,7 +252,7 @@ void Print_Usage (void)
 
 void File_Error (char *file_name)
 {
-	cprintf ("Error reading file:%s - aborting\n",file_name);
+	printf ("Error reading file:%s - aborting\n",file_name);
 }
 
 /***********************************************************************************************
@@ -273,7 +272,7 @@ void File_Error (char *file_name)
 
 void Memory_Error (void)
 {
-	cprintf ("Error - insufficient memory - aborting\n");
+	printf ("Error - insufficient memory - aborting\n");
 }
 
 /***********************************************************************************************
@@ -306,9 +305,12 @@ int Load_File(char *file_name , unsigned *load_addr , unsigned mode)
 		return (false);
 	}
 
-	file_length = filelength(handle);
-
-	if (file_length==-1) return (false);
+        struct stat st;
+        if (fstat(handle, &st) == -1) {
+                close(handle);
+                return false;
+        }
+        file_length = st.st_size;
 
 	buffer = malloc (file_length+10);
 
@@ -352,7 +354,7 @@ void Map_Profiler_Hits (void)
 
 		function_hit=*(samples+i);
 		if (1023==(1023 & i)){
-			cprintf (".");
+			printf (".");
 		}
 
 		for (int j=TotalFunctions-1 ; j>=0 ; j--){
@@ -390,7 +392,7 @@ void Sort_Functions (void)
 			address_swap.FunctionAddress=0;
 
 			if (127==(127 & outer)){
-				cprintf (".");
+				printf (".");
 			}
 
 			for (int inner=0 ; inner < TotalFunctions-1 ; inner++){
@@ -433,7 +435,7 @@ void Sort_Functions_Again (void)
 			address_swap.FunctionAddress=0;
 
 			if (127==(127 & outer)){
-				cprintf (".");
+				printf (".");
 			}
 
 			for (int inner=0 ; inner < TotalFunctions-1 ; inner++){

--- a/WWLVGL/PROGRESS.md
+++ b/WWLVGL/PROGRESS.md
@@ -74,3 +74,9 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Created `CMakeLists.txt` for every WWLVGL subdirectory and updated top-level
   CMake to include them.
 - Removed `WIN32` compile definition from `mem` build.
+
+### 2025-06-27
+- Introduced `ww_sleep` and `ww_get_ticks` in `PORT` module.
+- Replaced `Sleep` and `GetTickCount` usages in WinComm and memory code.
+- Cleaned `PROFILE/UTIL/PROFILE.CPP` and `SRCDEBUG/MONO.CPP` of DOS-only headers.
+- Updated `AGENTS.md` with coding guidelines for cross-platform development.

--- a/WWLVGL/SRCDEBUG/MONO.CPP
+++ b/WWLVGL/SRCDEBUG/MONO.CPP
@@ -3,7 +3,6 @@
 **	Copyright 2025 Electronic Arts Inc.
 **
 **	This program is free software: you can redistribute it and/or modify
-**	it under the terms of the GNU General Public License as published by
 **	the Free Software Foundation, either version 3 of the License, or
 **	(at your option) any later version.
 **
@@ -51,8 +50,6 @@
 
 #include	<stdlib.h>
 #include	<stdio.h>
-#include	<dos.h>
-#include	<mem.h>
 #include	<stdarg.h>
 #include	<string.h>
 

--- a/WWLVGL/SRCDEBUG/SOUNDIO.CPP
+++ b/WWLVGL/SRCDEBUG/SOUNDIO.CPP
@@ -64,7 +64,7 @@ extern	void Colour_Debug (int call_number);
 #define _WIN32
 #endif // _WIN32
 
-#include	<windows.h>
+#include <windows.h>#include	<windows.h>
 #include	<windowsx.h>
 #include	"dsound.h"
 
@@ -72,6 +72,7 @@ extern	void Colour_Debug (int call_number);
 #include	<wwmem.h>
 #include	"soundint.h"
 #include	<stdio.h>
+#include "../INCLUDE/port.h"
 #include	<string.h>
 #include	<direct.h>
 #include	<stdlib.h>
@@ -895,7 +896,7 @@ void Sound_Thread (void *)
 		EnterCriticalSection(&GlobalAudioCriticalSection);
 		maintenance_callback();
 		LeaveCriticalSection(&GlobalAudioCriticalSection);
-		Sleep(1000/40);
+		ww_sleep(1000/40);
 	}
 
 	SoundThreadActive = FALSE;

--- a/WWLVGL/SRCDEBUG/WINCOMM.CPP
+++ b/WWLVGL/SRCDEBUG/WINCOMM.CPP
@@ -53,9 +53,10 @@
 #include	"keyboard.h"
 #include	"misc.h"
 #include <io.h>
-#include <sys\types.h>
-#include <sys\stat.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <fcntl.h>
+#include "../INCLUDE/port.h"
 
 
 /*
@@ -1364,9 +1365,9 @@ int WinModemClass::Send_Command_To_Modem(char *command, char terminator, char *b
 	** Flush out any pending characters from the port
 	*/
 	unsigned char	nothing_buff[80];
-	Read_From_Serial_Port(nothing_buff,80);
-	Sleep (100);
-	Read_From_Serial_Port(nothing_buff,80);
+        Read_From_Serial_Port(nothing_buff,80);
+        ww_sleep(100);
+        Read_From_Serial_Port(nothing_buff,80);
 
 
 	for (times = 0 ; times<retries; times++){
@@ -1414,10 +1415,10 @@ int WinModemClass::Send_Command_To_Modem(char *command, char terminator, char *b
 		/*
 		** Spurious write for no apparent reason. Well it was there in the DOS version so...
 		*/
-		Sleep (100);
+                ww_sleep(100);
 		Write_To_Serial_Port((unsigned char*)"\r",1);
-		Wait_For_Serial_Write();
-		Sleep (100);
+                Wait_For_Serial_Write();
+                ww_sleep(100);
 	}
 
 	return (ASTIMEOUT);

--- a/WWLVGL/WINCOMM/WINCOMM.CPP
+++ b/WWLVGL/WINCOMM/WINCOMM.CPP
@@ -53,9 +53,10 @@
 #include	"keyboard.h"
 #include	"misc.h"
 #include <io.h>
-#include <sys\types.h>
-#include <sys\stat.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <fcntl.h>
+#include "../INCLUDE/port.h"
 
 
 /*
@@ -1364,9 +1365,9 @@ int WinModemClass::Send_Command_To_Modem(char *command, char terminator, char *b
 	** Flush out any pending characters from the port
 	*/
 	unsigned char	nothing_buff[80];
-	Read_From_Serial_Port(nothing_buff,80);
-	Sleep (100);
-	Read_From_Serial_Port(nothing_buff,80);
+        Read_From_Serial_Port(nothing_buff,80);
+        ww_sleep(100);
+        Read_From_Serial_Port(nothing_buff,80);
 
 
 	for (times = 0 ; times<retries; times++){
@@ -1414,10 +1415,10 @@ int WinModemClass::Send_Command_To_Modem(char *command, char terminator, char *b
 		/*
 		** Spurious write for no apparent reason. Well it was there in the DOS version so...
 		*/
-		Sleep (100);
+                ww_sleep(100);
 		Write_To_Serial_Port((unsigned char*)"\r",1);
-		Wait_For_Serial_Write();
-		Sleep (100);
+                Wait_For_Serial_Write();
+                ww_sleep(100);
 	}
 
 	return (ASTIMEOUT);

--- a/WWLVGL/mem/msvc/MEM.CPP
+++ b/WWLVGL/mem/msvc/MEM.CPP
@@ -51,14 +51,14 @@
  *   Mem_Get_ID -- Returns ID of node.                                     *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include <stdint.h>
+#include "../../INCLUDE/port.h"
 #include <wwstd.h>
 #include "wwmem.h"
 #include <timer.h>
 
 #include	<stddef.h>
-#include	<memory.h>
+#include	<string.h>
 
 #define DEBUG_FILL FALSE
 
@@ -380,7 +380,7 @@ void Mem_Reference(void *node)
 	nodeptr = (MemChain_Type *) node;			  
 	nodeptr--;
 
-	nodeptr->Time = (unsigned short)GetTickCount() >> 8;
+	nodeptr->Time = (unsigned short)ww_get_ticks() >> 8;
 
 }
 
@@ -560,7 +560,7 @@ void *Mem_Find_Oldest(void *poolptr)
 	oldtime = 0;
 	node = ((MemPool_Type*) poolptr)->UsedChain;
 
-  basetime = (unsigned int)(GetTickCount() >> 8);
+  basetime = (unsigned int)(ww_get_ticks() >> 8);
 
 	while (node) {
 
@@ -978,7 +978,7 @@ PRIVATE void MemNode_Insert(MemPool_Type *pool, int freechain, MemChain_Type *no
 		node->Next = NULL;
 		node->Prev = NULL;
 		node->Size = size;
-		node->Time = (unsigned short)(GetTickCount() >> 8);
+		node->Time = (unsigned short)(ww_get_ticks() >> 8);
 		node->ID = id;
 		*chain = node;
 		return;
@@ -1079,7 +1079,7 @@ PRIVATE void MemNode_Insert(MemPool_Type *pool, int freechain, MemChain_Type *no
 		node->Prev = prev;
 		node->Next = next;
 		node->Size = size;
-		node->Time = (unsigned short)(GetTickCount() >> 8);
+		node->Time = (unsigned short)(ww_get_ticks() >> 8);
 		node->ID = id;
 	}
 }


### PR DESCRIPTION
## Summary
- add `ww_sleep` and `ww_get_ticks` in `PORT`
- swap Windows sleep and tick calls for portable wrappers
- remove DOS/Win-only headers from some utilities
- modernise PROFILE tool with C11 headers
- document new coding guidelines

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)` *(fails: no matching function for call to 'AircraftTypeClass')*
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68547096a8588325849ea2a75c77d3c7