### PR TITLE
Remove Windows includes

### DIFF
--- a/WWLVGL/AUDIO/OLD/SOUNDINT.CPP
+++ b/WWLVGL/AUDIO/OLD/SOUNDINT.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -59,8 +60,6 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include	<windows.h>
-#include	<windowsx.h>
 #include	"dsound.h"
 #include	<wwstd.h>
 #include "soundint.h"

--- a/WWLVGL/AUDIO/OLD/SOUNDIO.CPP
+++ b/WWLVGL/AUDIO/OLD/SOUNDIO.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -64,8 +65,6 @@ extern	void Colour_Debug (int call_number);
 #define _WIN32
 #endif // _WIN32
 
-#include	<windows.h>
-#include	<windowsx.h>
 #include	"dsound.h"
 
 #include	<mem.h>
@@ -894,7 +893,7 @@ void Sound_Thread (void *)
 		EnterCriticalSection(&GlobalAudioCriticalSection);
 		maintenance_callback();
 		LeaveCriticalSection(&GlobalAudioCriticalSection);
-		Sleep(1000/40);
+		ww_sleep(1000/40);
 	}
 
 	SoundThreadActive = FALSE;

--- a/WWLVGL/AUDIO/OLD/SOUNDLCK.CPP
+++ b/WWLVGL/AUDIO/OLD/SOUNDLCK.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -38,8 +39,6 @@
 #define _WIN32
 #endif // _WIN32
 #define WIN32
-#include <windows.h>
-#include <windowsx.h>
 #include <objbase.h>
 #include "dsound.h"
 #include <mem.h>

--- a/WWLVGL/AUDIO/OLD/TEST.CPP
+++ b/WWLVGL/AUDIO/OLD/TEST.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -18,8 +19,6 @@
 
 
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <windowsx.h>
 #include "audio.h"
 
 

--- a/WWLVGL/AUDIO/OLD/TST.CPP
+++ b/WWLVGL/AUDIO/OLD/TST.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -24,8 +25,6 @@
 #define WIN32
 #define __WIN32
 
-#include <windows.h>
-#include <windowsx.h>
 #include <ole2.h>
 
 main

--- a/WWLVGL/AUDIO/TEST.CPP
+++ b/WWLVGL/AUDIO/TEST.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -18,8 +19,6 @@
 
 
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <windowsx.h>
 #include "audio.h"
 
 

--- a/WWLVGL/AUDIO/TST.CPP
+++ b/WWLVGL/AUDIO/TST.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -24,8 +25,6 @@
 #define WIN32
 #define __WIN32
 
-#include <windows.h>
-#include <windowsx.h>
 #include <ole2.h>
 
 main

--- a/WWLVGL/DRAWBUFF/ICONCACH.CPP
+++ b/WWLVGL/DRAWBUFF/ICONCACH.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -52,7 +53,6 @@
 #define	WIN32_LEAN_AND_MEAN
 #define	_WIN32
 
-#include <windows.h>
 #include "ddraw.h"
 #include "misc.h"
 #include "iconcach.h"

--- a/WWLVGL/DRAWBUFF/TEST/TEST.BAK
+++ b/WWLVGL/DRAWBUFF/TEST/TEST.BAK
@@ -55,8 +55,6 @@
 
 
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <windowsx.h>
 #include "..\gbuffer.h"
 #include <ddraw.h>
 #include <font.h>

--- a/WWLVGL/DRAWBUFF/TEST/TEST.CPP
+++ b/WWLVGL/DRAWBUFF/TEST/TEST.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -55,8 +56,6 @@
 
 #define WIN32
 #define WIN32
-#include <windows.h>
-#include <windowsx.h>
 #include "..\gbuffer.h"
 #include <ddraw.h>
 #include <font.h>

--- a/WWLVGL/INCLUDE/misc.h
+++ b/WWLVGL/INCLUDE/misc.h
@@ -41,8 +41,6 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include <windows.h>
-#include <windowsx.h>
 #include <ddraw.h>
 
 extern	LPDIRECTDRAWSURFACE	PaletteSurface;

--- a/WWLVGL/INCLUDE/modemreg.h
+++ b/WWLVGL/INCLUDE/modemreg.h
@@ -23,7 +23,6 @@
 #define _WIN32
 #endif // _WIN32
 #endif	//WIN32
-#include <windows.h>
 
 
 

--- a/WWLVGL/INCLUDE/rawfile.h
+++ b/WWLVGL/INCLUDE/rawfile.h
@@ -47,12 +47,10 @@
 #define _WIN32
 #endif // _WIN32
 #endif
-#include <windows.h>
 
 //#include	<wwlib32.h>
 #include	<limits.h>
 #include	<errno.h>
-#include	<windows.h>
 //#include	<algo.h>
 #include	"wwfile.h"
 

--- a/WWLVGL/INCLUDE/wincomm.h
+++ b/WWLVGL/INCLUDE/wincomm.h
@@ -48,7 +48,6 @@
 #define	WIN32
 #define	_WIN32
 #endif	//WIN32
-#include <windows.h>
 
 typedef enum WinCommDialMethodType {
 	WC_TOUCH_TONE = 0,

--- a/WWLVGL/INCLUDE/wwstd.h
+++ b/WWLVGL/INCLUDE/wwstd.h
@@ -43,8 +43,6 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <windowsx.h>
 #endif
 
 // Note: SKB 4/11/94

--- a/WWLVGL/MISC/misc.h
+++ b/WWLVGL/MISC/misc.h
@@ -41,8 +41,6 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include <windows.h>
-#include <windowsx.h>
 #include <ddraw.h>
 
 extern	LPDIRECTDRAWSURFACE	PaletteSurface;

--- a/WWLVGL/MISC/wwstd.h
+++ b/WWLVGL/MISC/wwstd.h
@@ -47,8 +47,6 @@
 #endif // _WIN32
 #define WIN32 1
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <windowsx.h>
 #endif
 
 // Note: SKB 4/11/94

--- a/WWLVGL/PROFILE/PROFILE.CPP
+++ b/WWLVGL/PROFILE/PROFILE.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -55,8 +56,6 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include <windows.h>
-#include <windowsx.h>
 
 #include <wwstd.h>
 #include <rawfile.h>

--- a/WWLVGL/PROFILE/WPROFILE.CPP
+++ b/WWLVGL/PROFILE/WPROFILE.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -82,8 +83,6 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include <windows.h>
-#include <windowsx.h>
 #include <wwstd.h>
 #include <rawfile.h>
 #include <file.h>

--- a/WWLVGL/PROGRESS.md
+++ b/WWLVGL/PROGRESS.md
@@ -101,3 +101,8 @@ As the port progresses, updates on how each dependency has been replaced or stub
 - Replaced MessageBox calls in DDRAW.CPP with logging and migrated functions to the new API.
 - Replaced DirectSound usage in `SRCDEBUG/AUDIO/SOUNDIO.CPP` with the miniaudio device API.
 - Added a minimal `soundint.h` stub in the same folder to remove DirectSound buffer fields.
+
+### 2025-07-02
+- Removed `<windows.h>` and `<windowsx.h>` includes from legacy modules listed in `MIGRATION.md`.
+- Added `port.h` to provide `ww_sleep` and other wrappers.
+- Replaced a `Sleep` call in `AUDIO/OLD/SOUNDIO.CPP` with `ww_sleep`.

--- a/WWLVGL/RAWFILE/RAWFILE.CPP
+++ b/WWLVGL/RAWFILE/RAWFILE.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -53,7 +54,6 @@
 
 #define	WIN32
 #define	_WIN32
-#include 	<windows.h>
 
 #include	<stdlib.h>
 #include	<stdio.h>
@@ -146,9 +146,9 @@ void RawFileClass::Error(int error, int , char const *)
 	if (canretry) {
 		if (GraphicMode == TXT_MODE) strcat(message, "\n");
 #ifdef GERMAN
-		strcat(message, " Beliebige Taste dr…ken f〉 erneuten Versuch.");
+		strcat(message, " Beliebige Taste drﾂ…ken fﾂ〉 erneuten Versuch.");
 		if (GraphicMode == TXT_MODE) strcat(message, "\n");
-		strcat(message, " <ESC> dr…ken, um das Programm zu verlassen.");
+		strcat(message, " <ESC> drﾂ…ken, um das Programm zu verlassen.");
 #else
 #ifdef FRENCH
 		strcat(message, " Appuyez sur une touche pour recommencer.");
@@ -164,7 +164,7 @@ void RawFileClass::Error(int error, int , char const *)
 	} else {
 		if (GraphicMode == TXT_MODE) strcat(message, "\n");
 #ifdef GERMAN
-		strcat(message, " Beliebige Taste dr…ken, um das Programm zu verlassen.");
+		strcat(message, " Beliebige Taste drﾂ…ken, um das Programm zu verlassen.");
 #else
 #ifdef FRENCH
 		strcat(message, " Appuyez sur une touche pour quitter le programme.");

--- a/WWLVGL/RAWFILE/rawfile.h
+++ b/WWLVGL/RAWFILE/rawfile.h
@@ -45,12 +45,10 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include <windows.h>
 
 //#include	<wwlib32.h>
 #include	<limits.h>
 #include	<errno.h>
-#include	<windows.h>
 //#include	<algo.h>
 #include	"wwfile.h"
 

--- a/WWLVGL/SRCDEBUG/AUDIO/SOUNDINT.CPP
+++ b/WWLVGL/SRCDEBUG/AUDIO/SOUNDINT.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -59,8 +60,6 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include	<windows.h>
-#include	<windowsx.h>
 #include	"dsound.h"
 #include	<wwstd.h>
 #include "soundint.h"

--- a/WWLVGL/SRCDEBUG/AUDIO/SOUNDLCK.CPP
+++ b/WWLVGL/SRCDEBUG/AUDIO/SOUNDLCK.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -38,8 +39,6 @@
 #define _WIN32
 #endif // _WIN32
 #define WIN32
-#include <windows.h>
-#include <windowsx.h>
 #include <objbase.h>
 #include "dsound.h"
 #include <mem.h>

--- a/WWLVGL/SRCDEBUG/ICONCACH.CPP
+++ b/WWLVGL/SRCDEBUG/ICONCACH.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -52,7 +53,6 @@
 #define	WIN32_LEAN_AND_MEAN
 #define	_WIN32
 
-#include <windows.h>
 #include "ddraw.h"
 #include "misc.h"
 #include "iconcach.h"

--- a/WWLVGL/SRCDEBUG/PROFILE/PROFILE.CPP
+++ b/WWLVGL/SRCDEBUG/PROFILE/PROFILE.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -55,8 +56,6 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include <windows.h>
-#include <windowsx.h>
 
 #include <wwstd.h>
 #include <rawfile.h>

--- a/WWLVGL/SRCDEBUG/PROFILE/WPROFILE.CPP
+++ b/WWLVGL/SRCDEBUG/PROFILE/WPROFILE.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -82,8 +83,6 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include <windows.h>
-#include <windowsx.h>
 #include <wwstd.h>
 #include <rawfile.h>
 #include <file.h>

--- a/WWLVGL/SRCDEBUG/RAWFILE/RAWFILE.CPP
+++ b/WWLVGL/SRCDEBUG/RAWFILE/RAWFILE.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -53,7 +54,6 @@
 
 #define	WIN32
 #define	_WIN32
-#include 	<windows.h>
 
 #include	<stdlib.h>
 #include	<stdio.h>
@@ -146,9 +146,9 @@ void RawFileClass::Error(int error, int , char const *)
 	if (canretry) {
 		if (GraphicMode == TXT_MODE) strcat(message, "\n");
 #ifdef GERMAN
-		strcat(message, " Beliebige Taste dr…ken f〉 erneuten Versuch.");
+		strcat(message, " Beliebige Taste drﾂ…ken fﾂ〉 erneuten Versuch.");
 		if (GraphicMode == TXT_MODE) strcat(message, "\n");
-		strcat(message, " <ESC> dr…ken, um das Programm zu verlassen.");
+		strcat(message, " <ESC> drﾂ…ken, um das Programm zu verlassen.");
 #else
 #ifdef FRENCH
 		strcat(message, " Appuyez sur une touche pour recommencer.");
@@ -164,7 +164,7 @@ void RawFileClass::Error(int error, int , char const *)
 	} else {
 		if (GraphicMode == TXT_MODE) strcat(message, "\n");
 #ifdef GERMAN
-		strcat(message, " Beliebige Taste dr…ken, um das Programm zu verlassen.");
+		strcat(message, " Beliebige Taste drﾂ…ken, um das Programm zu verlassen.");
 #else
 #ifdef FRENCH
 		strcat(message, " Appuyez sur une touche pour quitter le programme.");

--- a/WWLVGL/SRCDEBUG/TEST.CPP
+++ b/WWLVGL/SRCDEBUG/TEST.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -18,8 +19,6 @@
 
 
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <windowsx.h>
 #include "audio.h"
 
 

--- a/WWLVGL/SRCDEBUG/TST.CPP
+++ b/WWLVGL/SRCDEBUG/TST.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -24,8 +25,6 @@
 #define WIN32
 #define __WIN32
 
-#include <windows.h>
-#include <windowsx.h>
 #include <ole2.h>
 
 main

--- a/WWLVGL/TIMER/timer.h
+++ b/WWLVGL/TIMER/timer.h
@@ -42,8 +42,6 @@
 #ifndef _WIN32 // Denzil 6/2/98 Watcom 11.0 complains without this check
 #define _WIN32
 #endif // _WIN32
-#include <windows.h>
-#include <windowsx.h>
 
 /*=========================================================================*/
 /* The following prototypes are for the file: TIMERA.ASM							*/

--- a/WWLVGL/WINCOMM/modemreg.h
+++ b/WWLVGL/WINCOMM/modemreg.h
@@ -23,7 +23,6 @@
 #define _WIN32
 #endif // _WIN32
 #endif	//WIN32
-#include <windows.h>
 
 
 

--- a/WWLVGL/WINCOMM/wincomm.h
+++ b/WWLVGL/WINCOMM/wincomm.h
@@ -48,7 +48,6 @@
 #define	WIN32
 #define	_WIN32
 #endif	//WIN32
-#include <windows.h>
 
 typedef enum WinCommDialMethodType {
 	WC_TOUCH_TONE = 0,

--- a/WWLVGL/WW_WIN/OLD/WINDOWS.CPP
+++ b/WWLVGL/WW_WIN/OLD/WINDOWS.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -51,7 +52,6 @@
 #include	<stdio.h>
 #include	<stdarg.h>
 #include <wwstd.h>
-#include "windows.h"
 #include <keyboard.h>
 #include	<font.h>
 #include <dipthong.h>

--- a/WWLVGL/WW_WIN/OLD/WINHIDE.CPP
+++ b/WWLVGL/WW_WIN/OLD/WINHIDE.CPP
@@ -1,3 +1,4 @@
+#include <port.h>
 /*
 **	Command & Conquer Red Alert(tm)
 **	Copyright 2025 Electronic Arts Inc.
@@ -39,7 +40,6 @@
 
 #include	<wwstd.h>
 #include	<keyboard.h>
-#include "windows.h"
 
 
 #if(IBM)


### PR DESCRIPTION
## Summary
- strip `<windows.h>` and `<windowsx.h>` from WWLVGL sources
- add `port.h` to modules needing portable wrappers
- replace `Sleep` with `ww_sleep`
- document progress

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"` *(fails: various missing definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68548977371c8325a6f0f06aeaa002b5