### PR TITLE
Fix header includes for core game classes

### DIFF
--- a/CODE/abstract.h
+++ b/CODE/abstract.h
@@ -38,6 +38,9 @@
 #ifndef ABSTRACT_H
 #define ABSTRACT_H
 
+#include "defines.h"
+
+
 DirType Direction(CELL cell1, CELL cell2);
 DirType Direction(COORDINATE coord1, COORDINATE coord2);
 int Distance(COORDINATE coord1, COORDINATE coord2);

--- a/CODE/mission.h
+++ b/CODE/mission.h
@@ -37,6 +37,7 @@
 
 #ifndef MISSION_H
 #define MISSION_H
+#include "defines.h"
 
 #include "object.h"
 #include	"monoc.h"

--- a/CODE/object.h
+++ b/CODE/object.h
@@ -37,6 +37,7 @@
 
 #ifndef OBJECT_H
 #define OBJECT_H
+#include "defines.h"
 
 #include	"abstract.h"
 

--- a/CODE/stage.h
+++ b/CODE/stage.h
@@ -37,6 +37,8 @@
 
 #ifndef STAGE_H
 #define STAGE_H
+#include "defines.h"
+#include "ftimer.h"
 
 class StageClass {
 

--- a/CODE/target.h
+++ b/CODE/target.h
@@ -37,6 +37,7 @@
 
 #ifndef TARGET_H
 #define TARGET_H
+#include "defines.h"
 
 
 inline RTTIType Target_Kind(TARGET a)


### PR DESCRIPTION
## Summary
- ensure `defines.h` is included in major game headers
- add missing timer header for `StageClass`
- run cmake build to check for issues

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11"`
- `cmake --build build` *(fails: all warnings being treated as errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855810dfb108325b2c984ce2a1015d1