### PR TITLE
Update build logic for LVGL

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -11,6 +11,7 @@ The original source relies on several legacy libraries that are no longer readil
 - **Greenleaf Communications Library (GCL)** – provides networking/communication routines. Substitute with standard networking APIs or remove if unused.
 - **Human Machine Interface (HMI) "Sound Operating System" (SOS)** – provides audio support. Replace with a modern audio library or stub.
 - **IPX networking components** – some modules expect IPX APIs. Implement wrappers around modern sockets or stub out for now.
+- **LVGL** – included as a Git submodule. Run `git submodule update --init src/lvgl` before building when `USE_LVGL` is enabled.
 
 | Library | Example locations | Replacement or stub | Remaining work |
 | ------- | ----------------- | ------------------ | --------------- |

--- a/WWLVGL/SRCDEBUG/VIDEO/CMakeLists.txt
+++ b/WWLVGL/SRCDEBUG/VIDEO/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.13)
 
-add_library(srcdebug_video_lib
-    surface_api.cpp
-)
-
-target_include_directories(srcdebug_video_lib PUBLIC
-    ${CMAKE_CURRENT_LIST_DIR}
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
-    ${CMAKE_CURRENT_LIST_DIR}/../../src/lvgl/src
-)
-
-target_compile_features(srcdebug_video_lib PUBLIC cxx_std_11)
-target_compile_options(srcdebug_video_lib PUBLIC -std=gnu++11)
+if(USE_LVGL)
+    add_library(srcdebug_video_lib
+        surface_api.cpp
+    )
+    target_include_directories(srcdebug_video_lib PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_LIST_DIR}/../INCLUDE
+        ${CMAKE_CURRENT_LIST_DIR}/../../src/lvgl/src
+    )
+    target_compile_features(srcdebug_video_lib PUBLIC cxx_std_11)
+    target_compile_options(srcdebug_video_lib PUBLIC -std=gnu++11)
+endif()


### PR DESCRIPTION
## Summary
- build `srcdebug_video_lib` only when `USE_LVGL` is ON
- document LVGL submodule requirement in `PROGRESS.md`

## Testing
- `cmake -S . -B build -DCMAKE_C_FLAGS="-std=gnu11" -DUSE_LVGL=ON -DLV_BUILD_CONF_PATH=src/lv_conf.h`
- `cmake --build build` *(fails: built target `srcdebug_video_lib` then stopped on gamecode)*

------
https://chatgpt.com/codex/tasks/task_e_68558ba622308325b9990589496da56c